### PR TITLE
vita: Support multitouch

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -94,26 +94,18 @@ static short a2m(unsigned char in) {
 
 #define lerp(value, from_max, to_max) ((((value*10) * (to_max*10))/(from_max*10))/10)
 
-#define TOUCH_TOP(scr) \
-   ((lerp((scr).report[0].y, 1087, 544) - 56) < 272)
+static bool TOUCH(SceTouchData scr, int lx, int ly, int rx, int ry) {
+    for (int i = 0; i < scr.reportNum; i++) {
+        int x = lerp(scr.report[i].x, 1919, 960);
+        int y = lerp(scr.report[i].y, 1087, 544);
+        if (x < lx || x > rx || y < ly || y > ry) continue;
+        return true;
+    }
+    return false;
+}
 
-#define TOUCH_BUTTOM(scr) \
-   ((lerp((scr).report[0].y, 1087, 544) - 56) >= 272)
-
-#define TOUCH_LEFT(scr, top) \
-  ((scr).reportNum > 0 && (lerp((scr).report[0].x, 1919, 960) - 50) < 480 && \
-   (top ? TOUCH_TOP((scr)) : TOUCH_BUTTOM((scr))))
-
-#define TOUCH_RIGHT(scr, top) \
-  ((scr).reportNum > 0 && (lerp((scr).report[0].x, 1919, 960) - 50) >= 480 && \
-   (top ? TOUCH_TOP((scr)) : TOUCH_BUTTOM((scr))))
-
-#define TOUCH_LEFT_BTN(scr, top, y) \
-  if (TOUCH_LEFT((scr), (top))) \
-    btn |= y
-
-#define TOUCH_RIGHT_BTN(scr, top, y) \
-  if (TOUCH_RIGHT((scr), (top))) \
+#define TOUCH_BTN(scr, lx, ly, rx, ry, y) \
+  if (TOUCH((scr), (lx), (ly), (rx), (ry))) \
     btn |= y
 
 static void vita_process_input(void) {
@@ -147,10 +139,10 @@ static void vita_process_input(void) {
     BTN(SCE_CTRL_CROSS, A_FLAG);
     BTN(SCE_CTRL_SQUARE, X_FLAG);
 
-    TOUCH_LEFT_BTN(back, false, LS_CLK_FLAG);
-    TOUCH_RIGHT_BTN(back, false, RS_CLK_FLAG);
+    TOUCH_BTN(back, 0, 272, 480, 544, LS_CLK_FLAG);
+    TOUCH_BTN(back, 480, 272, 960, 544, RS_CLK_FLAG);
 
-    LiSendControllerEvent(btn, TOUCH_LEFT(back, true) ? 0xff : 0, TOUCH_RIGHT(back, true) ? 0xff : 0, a2m(pad.lx), -a2m(pad.ly), a2m(pad.rx), -a2m(pad.ry));
+    LiSendControllerEvent(btn, TOUCH(back, 0, 0, 480, 272) ? 0xff : 0, TOUCH(back, 480, 0, 960, 272) ? 0xff : 0, a2m(pad.lx), -a2m(pad.ly), a2m(pad.rx), -a2m(pad.ry));
 
     sceKernelDelayThread(1 * 1000); // 1 ms
   }


### PR DESCRIPTION
Original code set not allow multitouch input.
So if input LT button, we can't input RT button at same time.

This patch change `TOUCH*` macro to function for solve problem, but spend more costs.
