### PR TITLE
vita: New configure option `disable_powersave`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(${PROJECT_NAME}.elf
 	src/audio/vita.c
 	src/video/vita.c
 	src/input/vita.c
+	src/power/vita.c
 	src/graphics.c
 	src/font.c
 
@@ -98,6 +99,8 @@ target_link_libraries(${PROJECT_NAME}.elf
 	-lSceVideodec_stub
 	-lSceCommonDialog_stub
 	-lSceAudio_stub
+	-lSceKernel_stub
+	-lScePower_stub
 )
 
 add_custom_target(${PROJECT_NAME}.vpk ALL

--- a/moonlight.conf
+++ b/moonlight.conf
@@ -37,3 +37,6 @@
 
 ## Back touchscreen deadzone in pixels, separated by "," (top, right, bottom, left)
 #backtouchscreen_deadzone = 0,0,0,0
+
+## Disable power save mode
+#disable_powersave = true

--- a/src/config.c
+++ b/src/config.c
@@ -254,6 +254,8 @@ bool config_file_parse(char* filename, PCONFIGURATION config) {
             &config->back_deadzone.right, 
             &config->back_deadzone.bottom, 
             &config->back_deadzone.left);
+      } else if (strcmp(key, "disable_powersave") == 0) {
+        config->disable_powersave = strcmp("true", value) == 0;
       } else {
         for (int i=0;long_options[i].name != NULL;i++) {
           if (long_options[i].has_arg == required_argument && strcmp(long_options[i].name, key) == 0) {
@@ -315,6 +317,7 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   config->localaudio = false;
   config->fullscreen = true;
   config->unsupported_version = false;
+  config->disable_powersave = true;
 
   config->inputsCount = 0;
   //config->mapping = get_path("mappings/default.conf", getenv("XDG_DATA_DIRS"));

--- a/src/config.h
+++ b/src/config.h
@@ -48,9 +48,12 @@ typedef struct _CONFIGURATION {
   bool unsupported_version;
   bool fronttouchscreen_buttons;
   struct touchscreen_deadzone back_deadzone;
+  bool disable_powersave;
   struct input_config inputs[MAX_INPUTS];
   int inputsCount;
 } CONFIGURATION, *PCONFIGURATION;
+
+extern CONFIGURATION config;
 
 bool inputAdded;
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -19,8 +19,18 @@
 
 #include "connection.h"
 #include "global.h"
+#include "config.h"
+#include "power/vita.h"
 
 #include <stdio.h>
+
+void connection_connection_started()
+{
+  vitapower_init();
+  if (config.disable_powersave) {
+    vitapower_disable_powersave();
+  }
+}
 
 void connection_connection_terminated()
 {
@@ -41,7 +51,7 @@ CONNECTION_LISTENER_CALLBACKS connection_callbacks = {
   .stageStarting = NULL,
   .stageComplete = NULL,
   .stageFailed = NULL,
-  .connectionStarted = NULL,
+  .connectionStarted = connection_connection_started,
   .connectionTerminated = connection_connection_terminated,
   .displayMessage = connection_display_message,
   .displayTransientMessage = connection_display_transient_message,

--- a/src/main.c
+++ b/src/main.c
@@ -55,7 +55,7 @@
 
 #include "graphics.h"
 
-static CONFIGURATION config = {0};
+CONFIGURATION config = {0};
 
 static void applist(PSERVER_DATA server) {
   PAPP_LIST list = NULL;

--- a/src/power/vita.c
+++ b/src/power/vita.c
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Moonlight Embedded.
+ *
+ * Copyright (C) 2015 Iwan Timmer, Sunguk Lee
+ *
+ * Moonlight is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moonlight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
+ */
+#include <stdbool.h>
+
+#include <psp2/kernel/processmgr.h>
+#include <psp2/power.h>
+
+static bool powersave = false;
+
+int vitapower_thread(SceSize args, void *argp) {
+  while (1) {
+    if (powersave) {
+      sceKernelPowerTick(SCE_KERNEL_POWER_TICK_DISABLE_AUTO_SUSPEND);
+      sceKernelPowerTick(SCE_KERNEL_POWER_TICK_DISABLE_OLED_OFF);
+    }
+    if (!scePowerIsBatteryCharging() && scePowerIsLowBattery()) {
+      // TODO print warning message
+    }
+    sceKernelDelayThread(10 * 1000 * 1000);
+  }
+  return 0;
+}
+
+void vitapower_init() {
+  SceUID thid = sceKernelCreateThread("vitapower_thread", vitapower_thread, 0x10000100, 0x40000, 0, 0, NULL);
+  if (thid >= 0)
+    sceKernelStartThread(thid, 0, NULL);
+}
+
+void vitapower_disable_powersave() {
+  powersave = true;
+}

--- a/src/power/vita.h
+++ b/src/power/vita.h
@@ -1,0 +1,21 @@
+/*
+ * This file is part of Moonlight Embedded.
+ *
+ * Copyright (C) 2015 Iwan Timmer, Sunguk Lee
+ *
+ * Moonlight is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moonlight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+void vitapower_init();
+void vitapower_disable_powersave();


### PR DESCRIPTION
Add new options `disable_powersave`, default is true.

If option set true, psvita never go suspend mode on connect
