### PR TITLE
vita: Fix build fail about config variable

### DIFF
--- a/src/input/vita.c
+++ b/src/input/vita.c
@@ -62,7 +62,6 @@ enum {
   RIGHTY
 } PadSection;
 
-static CONFIGURATION config = {0};
 static struct mapping map = {0};
 
 #define lerp(value, from_max, to_max) ((((value*10) * (to_max*10))/(from_max*10))/10)


### PR DESCRIPTION
```
Scanning dependencies of target moonlight.elf
[  1%] Building C object CMakeFiles/moonlight.elf.dir/src/input/vita.c.obj
/home/d3m3vilurr/works/vita/vita-moonlight/src/input/vita.c:65:22: error: static declaration of 'config' follows non-static declaration
 static CONFIGURATION config = {0};
                      ^~~~~~
In file included from /home/d3m3vilurr/works/vita/vita-moonlight/src/input/vita.c:31:0:
/home/d3m3vilurr/works/vita/vita-moonlight/src/input/../config.h:56:22: note: previous declaration of 'config' was here
 extern CONFIGURATION config;
                      ^~~~~~
```
#5 and #6 make this problem.
