### PR TITLE
Store debugging logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TITLE_ID "XYZZ00002")
 set(CMAKE_C_FLAGS "-Wl,-q -O3 -g -std=c99 -Dntohs=__builtin_bswap16 -Dhtons=__builtin_bswap16 -Dntohl=__builtin_bswap32 -Dhtonl=__builtin_bswap32 -DENET_DEBUG=1")
 
 include_directories(
+    include/
 	third_party/moonlight-common-c/src/
 	libgamestream/
 	third_party/libuuid/src/

--- a/include/debug.h
+++ b/include/debug.h
@@ -1,0 +1,6 @@
+#ifndef __DEBUG_H__
+#define __DEBUG_H__
+
+void DEBUG_PRINT(const char *s, ...);
+
+#endif

--- a/src/config.c
+++ b/src/config.c
@@ -228,6 +228,8 @@ static int ini_handle(void *out, const char *section, const char *name,
       config->localaudio = BOOL(value);
     } else if (strcmp(name, "disable_powersave") == 0) {
       config->disable_powersave = BOOL(value);
+    } else if (strcmp(name, "save_debug_log") == 0) {
+      config->save_debug_log = BOOL(value);
     } else if (strcmp(name, "mapping") == 0) {
       config->mapping = STR(value);
     }
@@ -270,6 +272,7 @@ void config_save(char* filename, PCONFIGURATION config) {
     write_config_string(fd, "app", config->app);
 
   write_config_bool(fd, "disable_powersave", config->disable_powersave);
+  write_config_bool(fd, "save_debug_log", config->save_debug_log);
 
   write_config_section(fd, "backtouchscreen_deadzone");
   write_config_int(fd, "top",     config->back_deadzone.top);

--- a/src/config.h
+++ b/src/config.h
@@ -56,6 +56,7 @@ typedef struct _CONFIGURATION {
   struct touchscreen_deadzone back_deadzone;
   struct special_keys special_keys;
   bool disable_powersave;
+  bool save_debug_log;
   struct input_config inputs[MAX_INPUTS];
   int inputsCount;
 } CONFIGURATION, *PCONFIGURATION;

--- a/src/config.h
+++ b/src/config.h
@@ -19,6 +19,7 @@
 
 #include <Limelight.h>
 
+#include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -59,6 +60,7 @@ typedef struct _CONFIGURATION {
   bool save_debug_log;
   struct input_config inputs[MAX_INPUTS];
   int inputsCount;
+  FILE *log_file;
 } CONFIGURATION, *PCONFIGURATION;
 
 extern CONFIGURATION config;

--- a/src/connection.c
+++ b/src/connection.c
@@ -18,7 +18,6 @@
  */
 
 #include "connection.h"
-#include "global.h"
 #include "config.h"
 #include "power/vita.h"
 #include "input/vita.h"
@@ -27,6 +26,8 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+
+#include "debug.h"
 
 static int connection_status = LI_READY;
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -50,19 +50,23 @@ void start_output() {
 void connection_connection_started() {
   connection_status = LI_CONNECTED;
   start_output();
+  DEBUG_PRINT("connection started\n");
 }
 
 void connection_connection_terminated() {
   stop_output();
   connection_status = LI_READY;
+  DEBUG_PRINT("connection terminated\n");
 }
 
 void connection_display_message(char *msg) {
   printf("%s\n", msg);
+  DEBUG_PRINT("display_message: %s\n", msg);
 }
 
 void connection_display_transient_message(char *msg) {
   printf("%s\n", msg);
+  DEBUG_PRINT("display_transient_message: %s\n", msg);
 }
 
 void connection_reset() {
@@ -86,9 +90,17 @@ void connection_terminate() {
   connection_status = LI_READY;
 }
 
+void connection_stage_starting(int stage) {
+  DEBUG_PRINT("connection_stage_starting - stage: %d\n", stage);
+}
+void connection_stage_complate(int stage) {
+  DEBUG_PRINT("connection_stage_complate - stage: %d\n", stage);
+}
+
 void connection_stage_failed(int stage, long code) {
   connection_failed_stage = stage;
   connection_failed_stage_code = code;
+  DEBUG_PRINT("connection_stage_failed - stage: %d, %d\n", stage, code);
 }
 
 bool connection_is_ready() {
@@ -100,8 +112,8 @@ int connection_get_status() {
 }
 
 CONNECTION_LISTENER_CALLBACKS connection_callbacks = {
-  .stageStarting = NULL,
-  .stageComplete = NULL,
+  .stageStarting = connection_stage_starting,
+  .stageComplete = connection_stage_complate,
   .stageFailed = connection_stage_failed,
   .connectionStarted = connection_connection_started,
   .connectionTerminated = connection_connection_terminated,

--- a/src/global.c
+++ b/src/global.c
@@ -22,6 +22,7 @@
 #include <pthread.h>
 
 #include "config.h"
+#include "debug.h"
 
 // pthread_t main_thread_id;
 

--- a/src/global.c
+++ b/src/global.c
@@ -17,11 +17,30 @@
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdarg.h>
 #include <signal.h>
 #include <pthread.h>
+
+#include "config.h"
 
 // pthread_t main_thread_id;
 
 void quit() {
   // pthread_kill(main_thread_id, SIGTERM);
+}
+
+void DEBUG_PRINT(const char *s, ...) {
+  if (!config.save_debug_log) {
+    return;
+  }
+
+  va_list va;
+  char buffer[1024];
+
+  va_start(va, s);
+  vsprintf(buffer, s, va);
+  va_end(va);
+
+  fprintf(config.log_file, buffer);
+  fflush(config.log_file);
 }

--- a/src/global.h
+++ b/src/global.h
@@ -22,5 +22,3 @@
 // extern pthread_t main_thread_id;
 
 void quit();
-
-void DEBUG_PRINT(const char *s, ...);

--- a/src/global.h
+++ b/src/global.h
@@ -22,3 +22,5 @@
 // extern pthread_t main_thread_id;
 
 void quit();
+
+void DEBUG_PRINT(const char *s, ...);

--- a/src/main.c
+++ b/src/main.c
@@ -165,5 +165,7 @@ int main(int argc, char* argv[]) {
   vitapower_config(config);
   vitainput_config(config);
 
+  config.log_file = fopen("ux0:data/moonlight/moonlight.log", "w");
+
   gui_loop();
 }


### PR DESCRIPTION
New configure options `save_debug_log`

If enable this flag, currently, save connection logs to `ux0:data/moonlight/moonlight.log`
But sadly, we still cannot detect detail error information of `moonlight-common-c` like `RTSP handshake`.
This project use `stderr` for the logging & always return same error code(-1)
so sometimes we need to modify this project.

Anyway this hacky print method will help debugging for user's specific problem at next times.
