### PR TITLE
Add releasing helper script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+## Unreleased
+
+## 0.1.1
+* Fix connection problem on the GFE 2.2.3 (#66)
+* Improve logging datas (#67, #68)
+* Support newer vitasdk (#70)
+
+## 0.1.0
+* Add new option for store debugging log (#53)
+* Fix crash at quit application (#54)
+* Add livearea (#62)
+* Add new option for mouse acceleration (#63)
+* Cleanup codes. (#60)
+* Now remove alpha mark. but still lower version :) (#64)
+
+## alpha6
+* Reimplement input & config process for the improve stability (#47)
+* Fix little memory leaks (#47)
+* Fix crash if have too many moonlight supporting games (#47)
+* Fix crash at press circle button on the connect menu (#47)
+* Fix bug about not detect device model (#50)
+* Fix cannot use analog sticks on the VITA 2000 (#50)
+* Change priority of input thread for the high bitrate connection (#50)
+* Update mapping values & add new mapping file for the PSTV (#51)
+
+## alpha5
+* Fix crash at first time (dcd1dc8)
+* Improve input packet handle (#24)
+* Change connection option (#26)
+* Code cleanup for input handling (#27, #30, #31)
+* Support L2/R2/L3/R3 Buttons on PSTV (#36)
+* Update build toolchains & Fix connection problems under GFE 3.0 (#39)
+
+## alpha4
+* Support GUI (#13)
+* Support editing config file (#4)
+* Support input mapping (#5)
+* Add new config options for power saving (#6)
+* Turn safe application (#7)
+
+## alpha3
+* Support virtual button for L2/R2/L3/R3 using touchscreen (#1, #2)
+* Support mouse move and click using touchscreen (#3)
+
+## alpha2
+* Support custom settings; screen resolution, framerate and bitrate (d145403)
+
+## alpha1
+* Initial release (04a7c1d)

--- a/release.py
+++ b/release.py
@@ -1,0 +1,72 @@
+#/usr/bin/env python
+import sys
+
+def ver2appver(version):
+    try:
+        versions = map(int, version.split('.'))
+        return '%02d.%02d' % tuple(versions[:2])
+    except ValueError:
+        return '00.00'
+
+if len(sys.argv) < 2:
+    version = raw_input("new release version? ")
+else:
+    version = sys.argv[1]
+
+versions = map(int, version.split('.'))
+if len(versions) != 3:
+    print("version format must be A.B.C");
+    raise SystemExit(1)
+
+# update livearea
+with open('sce_sys/livearea/contents/template.xml.format') as f:
+    template = f.read()
+    with open('sce_sys/livearea/contents/template.xml', 'w') as w:
+        w.write(template.format(version=version))
+
+# update cmake version information
+lines = []
+with open('CMakeLists.txt') as f:
+    for line in f.readlines():
+        if 'set(VERSION_MAJOR' in line:
+            line = 'set(VERSION_MAJOR "%d")\n' % versions[0]
+        elif 'set(VERSION_MINOR' in line:
+            line = 'set(VERSION_MINOR "%d")\n' % versions[1]
+        elif 'set(VERSION_PATCH' in line:
+            line = 'set(VERSION_PATCH "%d")\n' % versions[2]
+        lines.append(line)
+with open('CMakeLists.txt', 'w') as w:
+    w.write(''.join(lines))
+
+# update release note
+lines = []
+groups = []
+with open('CHANGELOG.md') as f:
+    group = dict(version=None)
+    for line in f.readlines():
+        if '## Unreleased' in line:
+            lines.append('## Unreleased\n\n')
+            line = '## %s\n' % version
+        lines.append(line)
+        if '## ' in line:
+            app_ver = ver2appver(line.lstrip('## ').strip())
+            if group['version'] != app_ver:
+                group = dict(version=app_ver, item=[])
+                groups.append(group)
+        group['item'].append(line.strip())
+with open('CHANGELOG.md', 'w') as w:
+    w.write(''.join(lines))
+
+with open('resources/changeinfo.xml', 'w') as w:
+    w.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+    w.write('<changeinfo>\n')
+    pos = w.tell() + 14 # endtag length
+    for group in groups:
+        entry = ['<changes app_ver="%s"><![CDATA[\n' % group['version'],
+                 '<br>\n'.join(group['item']),
+                 ']]></changes>\n']
+        entry = ''.join(entry)
+        if pos + len(entry.encode('utf8')) > 65536: # prevent over 64k
+            break
+        w.write(entry)
+    w.write('</changeinfo>\n')

--- a/resources/changeinfo.xml
+++ b/resources/changeinfo.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<changeinfo>
+<changes app_ver="00.01"><![CDATA[
+## 0.1.1<br>
+* Fix connection problem on the GFE 2.2.3 (#66)<br>
+* Improve logging datas (#67, #68)<br>
+* Support newer vitasdk (#70)<br>
+<br>
+## 0.1.0<br>
+* Add new option for store debugging log (#53)<br>
+* Fix crash at quit application (#54)<br>
+* Add livearea (#62)<br>
+* Add new option for mouse acceleration (#63)<br>
+* Cleanup codes. (#60)<br>
+* Now remove alpha mark. but still lower version :) (#64)<br>
+]]></changes>
+<changes app_ver="00.00"><![CDATA[
+## alpha6<br>
+* Reimplement input & config process for the improve stability (#47)<br>
+* Fix little memory leaks (#47)<br>
+* Fix crash if have too many moonlight supporting games (#47)<br>
+* Fix crash at press circle button on the connect menu (#47)<br>
+* Fix bug about not detect device model (#50)<br>
+* Fix cannot use analog sticks on the VITA 2000 (#50)<br>
+* Change priority of input thread for the high bitrate connection (#50)<br>
+* Update mapping values & add new mapping file for the PSTV (#51)<br>
+<br>
+## alpha5<br>
+* Fix crash at first time (dcd1dc8)<br>
+* Improve input packet handle (#24)<br>
+* Change connection option (#26)<br>
+* Code cleanup for input handling (#27, #30, #31)<br>
+* Support L2/R2/L3/R3 Buttons on PSTV (#36)<br>
+* Update build toolchains & Fix connection problems under GFE 3.0 (#39)<br>
+<br>
+## alpha4<br>
+* Support GUI (#13)<br>
+* Support editing config file (#4)<br>
+* Support input mapping (#5)<br>
+* Add new config options for power saving (#6)<br>
+* Turn safe application (#7)<br>
+<br>
+## alpha3<br>
+* Support virtual button for L2/R2/L3/R3 using touchscreen (#1, #2)<br>
+* Support mouse move and click using touchscreen (#3)<br>
+<br>
+## alpha2<br>
+* Support custom settings; screen resolution, framerate and bitrate (d145403)<br>
+<br>
+## alpha1<br>
+* Initial release (04a7c1d)]]></changes>
+</changeinfo>

--- a/sce_sys/livearea/contents/template.xml.format
+++ b/sce_sys/livearea/contents/template.xml.format
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<livearea style="a4" format-ver="01.00" content-rev="1">
+    <livearea-background>
+        <image>bg.png</image>
+    </livearea-background>
+
+    <gate>
+        <startup-image>startup.png</startup-image>
+    </gate>
+
+    <frame id="frame3">
+        <liveitem>
+            <text origin="background" align="center" line-align="center" text-valign="bottom">
+                <str size="50" bold="on" shadow="on">MOONLIGHT</str>
+            </text>
+        </liveitem>
+    </frame>
+
+    <frame id="frame4">
+        <liveitem>
+            <text origin="background" line-break="on" pre-br="on" align="center" line-align="center" text-valign="top">
+                <str size="22" bold="off" shadow="on" color="#dddddd">AN OPEN SOURCE
+NVIDIA GAMESTREAM CLIENT</str>
+            </text>
+        </liveitem>
+    </frame>
+
+    <frame id="frame5">
+        <liveitem>
+            <text origin="background" align="right" line-align="right" text-valign="bottom" margin-bottom="0" margin-right="20">
+                <str size="18" bold="off" shadow="on" color="#999999">v{version}</str>
+            </text>
+        </liveitem>
+    </frame>
+
+
+</livearea>


### PR DESCRIPTION
`release.py` auto modify `CHANGELOG.md`, `changeinfo.xml`, livearea, cmake.

note: henkaku block accessing `ux0:patch/XYZZ00002/sce_sys/changeinfo/changeinfo.xml`, so cannot overwrite patch note in application.
maybe we need writing taihen plugin or something :/