### PR TITLE
Fix build error about crypto engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ target_link_libraries(${PROJECT_NAME}.elf
 	-lcurl
 	-lz
 	-lssl
+	-lcrypto
 	-lopus
 
 	-lSceDisplay_stub


### PR DESCRIPTION
Last toolchain require to link libcrypto
