### PR TITLE
Update moonlight-common-c

### DIFF
--- a/src/audio/vita.c
+++ b/src/audio/vita.c
@@ -49,7 +49,7 @@ static void vita_renderer_cleanup() {
   }
 }
 
-static int vita_renderer_init(int audioConfiguration, POPUS_MULTISTREAM_CONFIGURATION opusConfig) {
+static int vita_renderer_init(int audioConfiguration, POPUS_MULTISTREAM_CONFIGURATION opusConfig, void* audioContext, int arFlags) {
   int rc;
   decoder = opus_multistream_decoder_create(opusConfig->sampleRate,
                                             opusConfig->channelCount,

--- a/src/gui/ui_connect.c
+++ b/src/gui/ui_connect.c
@@ -81,7 +81,7 @@ void ui_connect_stream(PSERVER_DATA server, int appId) {
 
   ret = LiStartConnection(&server->serverInfo, &config.stream, &connection_callbacks,
                           video_callback, platform_get_audio(system),
-                          NULL, drFlags);
+                          NULL, drFlags, NULL, 0);
 
   if (ret == 0) {
     server->currentGame = appId;


### PR DESCRIPTION
Changed LiStartConnection and AudioRendererInit.
(Ref: moonlight-stream/moonlight-common-c#31)

In our cases, not use audioContext yet.