### PR TITLE
Add "Swap X & O for Moonlight" option

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -100,6 +100,8 @@ static int ini_handle(void *out, const char *section, const char *name,
       config->enable_frame_pacer = BOOL(value);
     } else if (strcmp(name, "disable_powersave") == 0) {
       config->disable_powersave = BOOL(value);
+    } else if (strcmp(name, "jp_layout") == 0) {
+      config->jp_layout = BOOL(value);
     } else if (strcmp(name, "save_debug_log") == 0) {
       config->save_debug_log = BOOL(value);
     } else if (strcmp(name, "mapping") == 0) {
@@ -151,6 +153,7 @@ void config_save(const char* filename, PCONFIGURATION config) {
 
   write_config_bool(fd, "enable_frame_pacer", config->enable_frame_pacer);
   write_config_bool(fd, "disable_powersave", config->disable_powersave);
+  write_config_bool(fd, "jp_layout", config->jp_layout);
   write_config_bool(fd, "save_debug_log", config->save_debug_log);
 
   write_config_int(fd, "mouse_acceleration", config->mouse_acceleration);
@@ -172,6 +175,17 @@ void config_save(const char* filename, PCONFIGURATION config) {
   write_config_int(fd, "size",    config->special_keys.size);
 
   fclose(fd);
+}
+
+void update_layout() {
+  if (config.jp_layout) {
+    config.btn_confirm = SCE_CTRL_CIRCLE;
+    config.btn_cancel = SCE_CTRL_CROSS;
+  }
+  else {
+    config.btn_confirm = SCE_CTRL_CROSS;
+    config.btn_cancel = SCE_CTRL_CIRCLE;
+  }
 }
 
 void config_parse(int argc, char* argv[], PCONFIGURATION config) {
@@ -198,6 +212,7 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   config->unsupported_version = false;
   config->save_debug_log = false;
   config->disable_powersave = true;
+  config->jp_layout = false;
   config->enable_frame_pacer = true;
 
   config->special_keys.nw = INPUT_SPECIAL_KEY_PAUSE | INPUT_TYPE_SPECIAL;
@@ -217,6 +232,8 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   if (config_file) {
     config_file_parse(config_file, config);
   }
+
+  update_layout();
 
   if (config->config_file != NULL)
     config_save(config->config_file, config);

--- a/src/config.h
+++ b/src/config.h
@@ -23,6 +23,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include <psp2/ctrl.h> 
+
 #define MAX_INPUTS 6
 
 struct input_config {
@@ -40,6 +42,7 @@ struct special_keys {
 };
 
 typedef struct _CONFIGURATION {
+  // static configuration, value will be saved to config file
   STREAM_CONFIGURATION stream;
   char* app;
   char* action;
@@ -64,6 +67,10 @@ typedef struct _CONFIGURATION {
   int mouse_acceleration;
   bool enable_ref_frame_invalidation;
   FILE *log_file;
+  bool jp_layout;
+  // runtime configuration, value will be recreated at launch
+  SceCtrlButtons btn_confirm;
+  SceCtrlButtons btn_cancel;
 } CONFIGURATION, *PCONFIGURATION;
 
 extern CONFIGURATION config;
@@ -74,3 +81,4 @@ bool inputAdded;
 bool config_file_parse(char* filename, PCONFIGURATION config);
 void config_parse(int argc, char* argv[], PCONFIGURATION config);
 void config_save(const char* filename, PCONFIGURATION config);
+void update_layout();

--- a/src/gui/guilib.c
+++ b/src/gui/guilib.c
@@ -442,9 +442,9 @@ void display_alert(char *message, char *button_captions[], int buttons_count,
       continue;
     }
 
-    if (input.buttons & SCE_CTRL_CROSS) {
+    if (input.buttons & config.btn_confirm) {
       result = 0;
-    } else if (input.buttons & SCE_CTRL_CIRCLE) {
+    } else if (input.buttons & config.btn_cancel) {
       result = 1;
     } else if (input.buttons & SCE_CTRL_TRIANGLE) {
       result = 2;

--- a/src/gui/guilib.c
+++ b/src/gui/guilib.c
@@ -260,8 +260,8 @@ void draw_alert(char *message, menu_geom geom, char *buttons_captions[], int but
   char caption[256];
   strcpy(caption, "");
 
-  char *o_layout[4] = {"◯", "x", "△", "□"};
-  char *x_layout[4] = {"x", "◯", "△", "□"};
+  char *o_layout[4] = {"o", "x", "△", "□"};
+  char *x_layout[4] = {"x", "o", "△", "□"};
   char **icons = config.jp_layout ? o_layout : x_layout;
   char *default_captions[4] = {"Ok", "Cancel", "Options", "Delete"};
   for (int i = 0; i < buttons_count; i++) {

--- a/src/gui/guilib.c
+++ b/src/gui/guilib.c
@@ -1,5 +1,6 @@
 #include "guilib.h"
 
+#include "../config.h"
 #include "../platform.h"
 
 #include <stdarg.h>
@@ -259,7 +260,9 @@ void draw_alert(char *message, menu_geom geom, char *buttons_captions[], int but
   char caption[256];
   strcpy(caption, "");
 
-  char *icons[4] = {"x", "◯", "△", "□"};
+  char *o_layout[4] = {"◯", "x", "△", "□"};
+  char *x_layout[4] = {"x", "◯", "△", "□"};
+  char **icons = config.jp_layout ? o_layout : x_layout;
   char *default_captions[4] = {"Ok", "Cancel", "Options", "Delete"};
   for (int i = 0; i < buttons_count; i++) {
     char single_button_caption[64];
@@ -400,7 +403,7 @@ int display_menu(menu_entry menu[], int total_elements, menu_geom *geom_ptr,
       gui_global_loop_callback(menu[real_cursor].id, context, &input);
     }
 
-    if (input.buttons & SCE_CTRL_CIRCLE && (input.buttons & SCE_CTRL_HOLD) == 0) {
+    if (input.buttons & config.btn_cancel && (input.buttons & SCE_CTRL_HOLD) == 0) {
       if (!back_cb || back_cb(context) == 0) {
         exit_code = 1;
         goto error;

--- a/src/gui/ui.c
+++ b/src/gui/ui.c
@@ -36,7 +36,7 @@ enum {
 };
 
 int ui_main_menu_loop(int cursor, void *context, const input_data *input) {
-  if ((input->buttons & SCE_CTRL_CROSS) == 0 || (input->buttons & SCE_CTRL_HOLD) != 0) {
+  if ((input->buttons & config.btn_confirm) == 0 || (input->buttons & SCE_CTRL_HOLD) != 0) {
     return 0;
   }
   if (cursor >= MAIN_MENU_CONNECT_PAIRED && cursor < MAIN_MENU_QUIT) {

--- a/src/gui/ui_connect.c
+++ b/src/gui/ui_connect.c
@@ -134,7 +134,7 @@ int ui_connect_loop(int id, void *context, const input_data *input) {
     menu[i].disabled = (server.currentGame != 0);
   }
 
-  if ((input->buttons & SCE_CTRL_CROSS) == 0 || input->buttons & SCE_CTRL_HOLD) {
+  if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
     return 0;
   }
 

--- a/src/gui/ui_device.c
+++ b/src/gui/ui_device.c
@@ -189,7 +189,7 @@ int end_search_thread(SceUID thid) {
 }
 
 static int ui_search_device_callback(int id, void *context, const input_data *input) {
-  if ((input->buttons & SCE_CTRL_CROSS) == 0 || (input->buttons & SCE_CTRL_HOLD) != 0) {
+  if ((input->buttons & config.btn_confirm) == 0 || (input->buttons & SCE_CTRL_HOLD) != 0) {
     // if remain slot, reload discovered devices
     if (!DEVICE_ENTRY_IDX[DEVICE_VIEW_ITEM + found_device - 1]) {
       return 2;

--- a/src/gui/ui_settings.c
+++ b/src/gui/ui_settings.c
@@ -214,7 +214,7 @@ enum {
 static int select_special_key_loop(int id, void *context, const input_data *input) {
   int *code = context;
 
-  if ((input->buttons & SCE_CTRL_CROSS) == 0 || input->buttons & SCE_CTRL_HOLD) {
+  if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
     return 0;
   }
   if (id != SETTINGS_SELECT_SPECIAL_KEY_MANUAL) {
@@ -274,7 +274,7 @@ static int special_keys_loop(int id, void *context, const input_data *input) {
       config.special_keys.size += delta;
       break;
     default:
-      if ((input->buttons & SCE_CTRL_CROSS) == 0 || input->buttons & SCE_CTRL_HOLD) {
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
         break;
       }
       select_special_key_menu(&selected_ord);
@@ -381,6 +381,7 @@ enum {
   SETTINGS_ENABLE_STREAM_OPTIMIZE,
   SETTINGS_SAVE_DEBUG_LOG,
   SETTINGS_DISABLE_POWERSAVE,
+  SETTINGS_JP_LAYOUT,
   SETTINGS_ENABLE_FRAME_PACER,
   SETTINGS_ENABLE_MAPPING,
   SETTINGS_BACK_DEADZONE,
@@ -397,6 +398,7 @@ enum {
   SETTINGS_VIEW_ENABLE_STREAM_OPTIMIZE,
   SETTINGS_VIEW_SAVE_DEBUG_LOG,
   SETTINGS_VIEW_DISABLE_POWERSAVE,
+  SETTINGS_VIEW_JP_LAYOUT,
   SETTINGS_VIEW_ENABLE_FRAME_PACER,
   SETTINGS_VIEW_ENABLE_MAPPING,
   SETTINGS_VIEW_BACK_DEADZONE,
@@ -468,7 +470,7 @@ static int settings_loop(int id, void *context, const input_data *input) {
       did_change = 1;
       break;
     case SETTINGS_BITRATE:
-      if ((input->buttons & SCE_CTRL_CROSS) == 0 || input->buttons & SCE_CTRL_HOLD) {
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
         break;
       }
       char value[512];
@@ -484,49 +486,56 @@ static int settings_loop(int id, void *context, const input_data *input) {
       }
       break;
     case SETTINGS_SOPS:
-      if ((input->buttons & SCE_CTRL_CROSS) == 0 || input->buttons & SCE_CTRL_HOLD) {
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
         break;
       }
       did_change = 1;
       config.sops = !config.sops;
       break;
     case SETTINGS_ENABLE_FRAME_INVAL:
-      if ((input->buttons & SCE_CTRL_CROSS) == 0 || input->buttons & SCE_CTRL_HOLD) {
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
         break;
       }
       did_change = 1;
       config.enable_ref_frame_invalidation = !config.enable_ref_frame_invalidation;
       break;
     case SETTINGS_ENABLE_STREAM_OPTIMIZE:
-      if ((input->buttons & SCE_CTRL_CROSS) == 0 || input->buttons & SCE_CTRL_HOLD) {
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
         break;
       }
       did_change = 1;
       config.stream.streamingRemotely = config.stream.streamingRemotely ? 0 : 1;
       break;
     case SETTINGS_SAVE_DEBUG_LOG:
-      if ((input->buttons & SCE_CTRL_CROSS) == 0 || input->buttons & SCE_CTRL_HOLD) {
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
         break;
       }
       did_change = 1;
       config.save_debug_log = !config.save_debug_log;
       break;
     case SETTINGS_DISABLE_POWERSAVE:
-      if ((input->buttons & SCE_CTRL_CROSS) == 0 || input->buttons & SCE_CTRL_HOLD) {
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
         break;
       }
       did_change = 1;
       config.disable_powersave = !config.disable_powersave;
       break;
+    case SETTINGS_JP_LAYOUT:
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
+        break;
+      }
+      did_change = 1;
+      config.jp_layout = !config.jp_layout;
+      break;
     case SETTINGS_ENABLE_FRAME_PACER:
-      if ((input->buttons & SCE_CTRL_CROSS) == 0 || input->buttons & SCE_CTRL_HOLD) {
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
         break;
       }
       did_change = 1;
       config.enable_frame_pacer = !config.enable_frame_pacer;
       break;
     case SETTINGS_ENABLE_MAPPING:
-      if ((input->buttons & SCE_CTRL_CROSS) == 0 || input->buttons & SCE_CTRL_HOLD) {
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
         break;
       }
       did_change = 1;
@@ -538,14 +547,14 @@ static int settings_loop(int id, void *context, const input_data *input) {
       }
       break;
     case SETTINGS_BACK_DEADZONE:
-      if ((input->buttons & SCE_CTRL_CROSS) == 0 || input->buttons & SCE_CTRL_HOLD) {
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
         break;
       }
       deadzone_settings_menu();
       did_change = 1;
       break;
     case SETTINGS_SPECIAL_KEYS:
-      if ((input->buttons & SCE_CTRL_CROSS) == 0 || input->buttons & SCE_CTRL_HOLD) {
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
         break;
       }
       special_keys_menu();
@@ -602,6 +611,9 @@ static int settings_loop(int id, void *context, const input_data *input) {
   sprintf(current, "%s", config.disable_powersave ? "yes" : "no");
   MENU_REPLACE(SETTINGS_VIEW_DISABLE_POWERSAVE, current);
 
+  sprintf(current, "%s", config.jp_layout ? "yes" : "no");
+  MENU_REPLACE(SETTINGS_VIEW_JP_LAYOUT, current);
+
   sprintf(current, "%s", config.enable_frame_pacer ? "yes" : "no");
   MENU_REPLACE(SETTINGS_VIEW_ENABLE_FRAME_PACER, current);
 
@@ -625,6 +637,7 @@ static int settings_loop(int id, void *context, const input_data *input) {
 
 static int settings_back(void *context) {
   ui_settings_save_config();
+  update_layout();
   return 0;
 }
 
@@ -660,6 +673,7 @@ int ui_settings_menu() {
   MENU_CATEGORY("System");
   MENU_ENTRY(SETTINGS_SAVE_DEBUG_LOG, SETTINGS_VIEW_SAVE_DEBUG_LOG, "Enable debug log", "");
   MENU_ENTRY(SETTINGS_DISABLE_POWERSAVE, SETTINGS_VIEW_DISABLE_POWERSAVE, "Disable power save", "");
+  MENU_ENTRY(SETTINGS_JP_LAYOUT, SETTINGS_VIEW_JP_LAYOUT, "Swap X & O for Moonlight", "");
 
   MENU_CATEGORY("Input");
   MENU_ENTRY(SETTINGS_MOUSE_ACCEL, SETTINGS_VIEW_MOUSE_ACCEL, "Mouse acceleration", ICON_LEFT_RIGHT_ARROWS);


### PR DESCRIPTION
Currently Moonlight always treats X as confirm, and O as cancel. However, in some other regions (most notably in Japan) the role of those two buttons are swapped.
The role setting is stored in /CONFIG/SYSTEM/button_assign. However, to read this value you have to use sceRegMgrGetKeyInt, and this is a privileged API. Right now Moonlight is built as a [safe homebrew](https://github.com/xyzz/vita-moonlight/blob/vita/CMakeLists.txt#L158), so we can't use this API.
As such, this feature is presented as an end-user changeable setting.