### PR TITLE
Improve support for display ratio other than 16:9

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -98,6 +98,8 @@ static int ini_handle(void *out, const char *section, const char *name,
       config->localaudio = BOOL(value);
     } else if (strcmp(name, "enable_frame_pacer") == 0) {
       config->enable_frame_pacer = BOOL(value);
+    } else if (strcmp(name, "center_region_only") == 0) {
+      config->center_region_only = BOOL(value);
     } else if (strcmp(name, "disable_powersave") == 0) {
       config->disable_powersave = BOOL(value);
     } else if (strcmp(name, "jp_layout") == 0) {
@@ -154,6 +156,7 @@ void config_save(const char* filename, PCONFIGURATION config) {
     write_config_string(fd, "app", config->app);
 
   write_config_bool(fd, "enable_frame_pacer", config->enable_frame_pacer);
+  write_config_bool(fd, "center_region_only", config->center_region_only);
   write_config_bool(fd, "disable_powersave", config->disable_powersave);
   write_config_bool(fd, "jp_layout", config->jp_layout);
   write_config_bool(fd, "show_fps", config->show_fps);
@@ -218,6 +221,7 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   config->jp_layout = false;
   config->show_fps = false;
   config->enable_frame_pacer = true;
+  config->center_region_only = false;
 
   config->special_keys.nw = INPUT_SPECIAL_KEY_PAUSE | INPUT_TYPE_SPECIAL;
   config->special_keys.sw = SPECIAL_FLAG | INPUT_TYPE_GAMEPAD;

--- a/src/config.h
+++ b/src/config.h
@@ -63,6 +63,7 @@ typedef struct _CONFIGURATION {
   bool jp_layout;
   bool show_fps;
   bool enable_frame_pacer;
+  bool center_region_only;
   bool save_debug_log;
   struct input_config inputs[MAX_INPUTS];
   int inputsCount;

--- a/src/connection.c
+++ b/src/connection.c
@@ -146,6 +146,10 @@ bool connection_is_ready() {
   return connection_status != LI_DISCONNECTED;
 }
 
+bool connection_is_connected() {
+  return connection_status == LI_CONNECTED;
+}
+
 int connection_get_status() {
   return connection_status;
 }

--- a/src/connection.c
+++ b/src/connection.c
@@ -136,7 +136,7 @@ void connection_stage_complate(int stage) {
   vita_debug_log("connection_stage_complate - stage: %d\n", stage);
 }
 
-void connection_stage_failed(int stage, long code) {
+void connection_stage_failed(int stage, int code) {
   connection_failed_stage = stage;
   connection_failed_stage_code = code;
   vita_debug_log("connection_stage_failed - stage: %d, %d\n", stage, code);

--- a/src/connection.h
+++ b/src/connection.h
@@ -53,4 +53,5 @@ int connection_resume();
 int connection_terminate();
 
 bool connection_is_ready();
+bool connection_is_connected();
 int connection_get_status();

--- a/src/device.c
+++ b/src/device.c
@@ -14,9 +14,7 @@
 #define DEVICE_FILE "device.ini"
 
 #define BOOL(v) strcmp((v), "true") == 0
-#define INT(v) atoi((v))
 #define write_bool(fd, key, value) fprintf(fd, "%s = %s\n", key, value ? "true" : "false");
-#define write_int(fd, key, value) fprintf(fd, "%s = %i\n", key, value)
 #define write_string(fd, key, value) fprintf(fd, "%s = %s\n", key, value)
 
 device_infos_t known_devices = {0};
@@ -45,8 +43,8 @@ static int device_ini_handle(void *out, const char *section, const char *name,
     strncpy(info->internal, value, 255);
   } else if (strcmp(name, "external") == 0) {
     strncpy(info->external, value, 255);
-  } else if (strcmp(name, "last_used_address") == 0) {
-    info->last_used_address = INT(value);
+  } else if (strcmp(name, "prefer_external") == 0) {
+    info->prefer_external = BOOL(value);
   }
   return 1;
 }
@@ -85,7 +83,7 @@ device_info_t* append_device(device_info_t *info) {
   p->paired = info->paired;
   strncpy(p->internal, info->internal, 255);
   strncpy(p->external, info->external, 255);
-  p->last_used_address = info->last_used_address;
+  p->prefer_external = info->prefer_external;
   vita_debug_log("append_device: device %s is added to the list\n", p->name);
 
   known_devices.count++;
@@ -102,7 +100,7 @@ bool update_device(device_info_t *info) {
   p->paired = info->paired;
   strncpy(p->internal, info->internal, 255);
   strncpy(p->external, info->external, 255);
-  p->last_used_address = info->last_used_address;
+  p->prefer_external = info->prefer_external;
   return true;
 }
 
@@ -150,7 +148,7 @@ bool load_device_info(device_info_t *info) {
     vita_debug_log("load_device_info:   info->paired = %s\n", info->paired ? "true" : "false");
     vita_debug_log("load_device_info:   info->internal = %s\n", info->internal);
     vita_debug_log("load_device_info:   info->external = %s\n", info->external);
-    vita_debug_log("load_device_info:   info->last_used_address = %i\n", info->last_used_address);
+    vita_debug_log("load_device_info:   info->prefer_external = %s\n", info->prefer_external ? "true" : "false");
     return true;
   } else {
     vita_debug_log("load_device_info: ini_parse returned %d\n", ret);
@@ -179,8 +177,8 @@ void save_device_info(const device_info_t *info) {
   vita_debug_log("save_device_info: external = %s\n", info->external);
   write_string(fd, "external", info->external);
 
-  vita_debug_log("save_device_info: last_used_address = %i\n", info->last_used_address);
-  write_int(fd, "last_used_address", info->last_used_address);
+  vita_debug_log("save_device_info: prefer_external = %s\n", info->prefer_external ? "true" : "false");
+  write_bool(fd, "prefer_external", info->prefer_external);
 
   fclose(fd);
   vita_debug_log("save_device_info: file closed\n");

--- a/src/device.h
+++ b/src/device.h
@@ -7,6 +7,7 @@ struct device_info {
   bool paired;
   char internal[256];
   char external[256];
+  int last_used_address;
 };
 
 typedef struct device_infos device_infos_t;

--- a/src/device.h
+++ b/src/device.h
@@ -7,7 +7,7 @@ struct device_info {
   bool paired;
   char internal[256];
   char external[256];
-  int last_used_address;
+  bool prefer_external;
 };
 
 typedef struct device_infos device_infos_t;

--- a/src/gui/ime.c
+++ b/src/gui/ime.c
@@ -68,7 +68,7 @@ void utf8_to_utf16(uint8_t *src, uint16_t *dst) {
   *dst = '\0';
 }
 
-void initImeDialog(SceImeType type, char *title, char *initial_text, int max_text_length) {
+void initImeDialog(SceImeType type, const char *title, char *initial_text, int max_text_length) {
   // Convert UTF8 to UTF16
   utf8_to_utf16((uint8_t *)title, ime_title_utf16);
   utf8_to_utf16((uint8_t *)initial_text, ime_initial_text_utf16);

--- a/src/gui/ime.c
+++ b/src/gui/ime.c
@@ -50,7 +50,7 @@ void utf16_to_utf8(uint16_t *src, uint8_t *dst) {
   *dst = '\0';
 }
 
-void utf8_to_utf16(uint8_t *src, uint16_t *dst) {
+void utf8_to_utf16(const uint8_t *src, uint16_t *dst) {
   int i;
   for (i = 0; src[i];) {
     if ((src[i] & 0xE0) == 0xE0) {
@@ -70,8 +70,8 @@ void utf8_to_utf16(uint8_t *src, uint16_t *dst) {
 
 void initImeDialog(SceImeType type, const char *title, char *initial_text, int max_text_length) {
   // Convert UTF8 to UTF16
-  utf8_to_utf16((uint8_t *)title, ime_title_utf16);
-  utf8_to_utf16((uint8_t *)initial_text, ime_initial_text_utf16);
+  utf8_to_utf16((const uint8_t *)title, ime_title_utf16);
+  utf8_to_utf16((const uint8_t *)initial_text, ime_initial_text_utf16);
 
   SceImeDialogParam param;
   sceImeDialogParamInit(&param);

--- a/src/gui/ui.c
+++ b/src/gui/ui.c
@@ -144,7 +144,7 @@ int global_loop(int cursor, void *ctx, const input_data *input) {
       sceKernelDelayThread(500 * 1000);
       connection_resume();
 
-      while (connection_get_status() == LI_CONNECTED) {
+      while (connection_is_connected()) {
         sceKernelDelayThread(500 * 1000);
       }
     }

--- a/src/gui/ui_connect.c
+++ b/src/gui/ui_connect.c
@@ -188,6 +188,7 @@ int ui_connect_loop(int id, void *context, const input_data *input) {
       display_error("Quitting failed: %d", ret);
       return 0;
 
+    // application launcher / resume
     default:
       vitapower_config(config);
       vitainput_config(config);
@@ -207,7 +208,7 @@ int ui_connect_loop(int id, void *context, const input_data *input) {
       }
 
 mainloop:
-      while (connection_get_status() == LI_CONNECTED) {
+      while (connection_is_connected()) {
         sceKernelDelayThread(500 * 1000);
       }
 

--- a/src/gui/ui_connect.c
+++ b/src/gui/ui_connect.c
@@ -477,28 +477,14 @@ void ui_connect_paired_device(device_info_t *info) {
   }
 
   char *addr = NULL;
-  switch (info->last_used_address)
-  {
-    case 1:
-      if (info->external && check_connection(info->name, info->external)) {
-        addr = info->external;
-        info->last_used_address = 1;
-      } else if (info->internal && check_connection(info->name, info->internal)) {
-        addr = info->internal;
-        info->last_used_address = 0;
-      }
-      break;
-    case 0:
-    default:
-      if (info->internal && check_connection(info->name, info->internal)) {
-        addr = info->internal;
-        info->last_used_address = 0;
-      } else if (info->external && check_connection(info->name, info->external)) {
-        addr = info->external;
-        info->last_used_address = 1;
-      }
-      break;
+  if (info->prefer_external && info->external && check_connection(info->name, info->external)) {
+    addr = info->external;
+  } else if (info->internal && check_connection(info->name, info->internal)) {
+    addr = info->internal;
+  } else if (info->external && check_connection(info->name, info->external)) {
+    addr = info->external;
   }
+  info->prefer_external = addr == info->external;
   save_device_info(info);
   
   if (addr == NULL) {

--- a/src/gui/ui_device.c
+++ b/src/gui/ui_device.c
@@ -208,7 +208,7 @@ static int ui_search_device_callback(int id, void *context, const input_data *in
       return 0;
     }
 
-    uint32_t extern_addr = 0;
+    unsigned int extern_addr = 0;
     if (LiFindExternalAddressIP4("stun.stunprotocol.org", 3478, &extern_addr) == 0) {
       struct sockaddr_in addr;
       addr.sin_family = AF_INET;

--- a/src/gui/ui_settings.c
+++ b/src/gui/ui_settings.c
@@ -383,6 +383,7 @@ enum {
   SETTINGS_DISABLE_POWERSAVE,
   SETTINGS_JP_LAYOUT,
   SETTINGS_SHOW_FPS,
+  SETTINGS_LOCAL_AUDIO,
   SETTINGS_ENABLE_FRAME_PACER,
   SETTINGS_ENABLE_MAPPING,
   SETTINGS_BACK_DEADZONE,
@@ -401,6 +402,7 @@ enum {
   SETTINGS_VIEW_DISABLE_POWERSAVE,
   SETTINGS_VIEW_JP_LAYOUT,
   SETTINGS_VIEW_SHOW_FPS,
+  SETTINGS_VIEW_LOCAL_AUDIO,
   SETTINGS_VIEW_ENABLE_FRAME_PACER,
   SETTINGS_VIEW_ENABLE_MAPPING,
   SETTINGS_VIEW_BACK_DEADZONE,
@@ -536,6 +538,13 @@ static int settings_loop(int id, void *context, const input_data *input) {
       did_change = 1;
       config.show_fps = !config.show_fps;
       break;
+    case SETTINGS_LOCAL_AUDIO:
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
+        break;
+      }
+      did_change = 1;
+      config.localaudio = !config.localaudio;
+      break;
     case SETTINGS_ENABLE_FRAME_PACER:
       if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
         break;
@@ -626,6 +635,9 @@ static int settings_loop(int id, void *context, const input_data *input) {
   sprintf(current, "%s", config.show_fps ? "yes" : "no");
   MENU_REPLACE(SETTINGS_VIEW_SHOW_FPS, current);
 
+  sprintf(current, "%s", config.localaudio ? "yes" : "no");
+  MENU_REPLACE(SETTINGS_VIEW_LOCAL_AUDIO, current);
+
   sprintf(current, "%s", config.enable_frame_pacer ? "yes" : "no");
   MENU_REPLACE(SETTINGS_VIEW_ENABLE_FRAME_PACER, current);
 
@@ -681,6 +693,7 @@ int ui_settings_menu() {
   MENU_ENTRY(SETTINGS_ENABLE_FRAME_INVAL, SETTINGS_VIEW_ENABLE_FRAME_INVAL, "Enable reference frame invalidation", "");
   MENU_ENTRY(SETTINGS_ENABLE_STREAM_OPTIMIZE, SETTINGS_VIEW_ENABLE_STREAM_OPTIMIZE, "Enable stream optimization", "");
   MENU_ENTRY(SETTINGS_ENABLE_FRAME_PACER, SETTINGS_VIEW_ENABLE_FRAME_PACER, "Enable frame pacer", "");
+  MENU_ENTRY(SETTINGS_LOCAL_AUDIO, SETTINGS_VIEW_LOCAL_AUDIO, "Enable local audio", "");
 
   MENU_CATEGORY("System");
   MENU_ENTRY(SETTINGS_SAVE_DEBUG_LOG, SETTINGS_VIEW_SAVE_DEBUG_LOG, "Enable debug log", "");

--- a/src/gui/ui_settings.c
+++ b/src/gui/ui_settings.c
@@ -442,16 +442,19 @@ static int settings_loop(int id, void *context, const input_data *input) {
       if (!left && !right) {
           break;
       }
-      char *resolutions[] = {"960x540", "960x544", "1280x720", "1920x1080"};
+      char *resolutions[] = {"960x544", "960x540", "1280x720", "1920x1080", "1280x540", "1680x720", "2560x1080"};
       sprintf(current, "%dx%d", config.stream.width, config.stream.height);
 
-      new_idx = move_idx_in_array(resolutions, 4, current, left ? -1 : +1);
+      new_idx = move_idx_in_array(resolutions, 7, current, left ? -1 : +1);
 
       switch (new_idx) {
-        case 0: config.stream.width = 960; config.stream.height = 540; break;
-        case 1: config.stream.width = 960; config.stream.height = 544; break;
+        case 0: config.stream.width = 960; config.stream.height = 544; break;
+        case 1: config.stream.width = 960; config.stream.height = 540; break;
         case 2: config.stream.width = 1280; config.stream.height = 720; break;
         case 3: config.stream.width = 1920; config.stream.height = 1080; break;
+        case 4: config.stream.width = 1280; config.stream.height = 540; break;
+        case 5: config.stream.width = 1680; config.stream.height = 720; break;
+        case 6: config.stream.width = 2560; config.stream.height = 1080; break;
       }
 
       did_change = 1;

--- a/src/gui/ui_settings.c
+++ b/src/gui/ui_settings.c
@@ -450,17 +450,17 @@ static int settings_loop(int id, void *context, const input_data *input) {
       if (!left && !right) {
           break;
       }
-      char *resolutions[] = {"960x544", "960x540", "1280x720", "1920x1080", "1280x540"};
+      char *resolutions[] = {"960x540", "960x544", "1280x540", "1280x720", "1920x1080"};
       sprintf(current, "%dx%d", config.stream.width, config.stream.height);
 
       new_idx = _move_idx_in_array(resolutions, current, left ? -1 : +1);
 
       switch (new_idx) {
-        case 0: config.stream.width = 960; config.stream.height = 544; break;
-        case 1: config.stream.width = 960; config.stream.height = 540; break;
-        case 2: config.stream.width = 1280; config.stream.height = 720; break;
-        case 3: config.stream.width = 1920; config.stream.height = 1080; break;
-        case 4: config.stream.width = 1280; config.stream.height = 540; break;
+        case 0: config.stream.width = 960; config.stream.height = 540; break;
+        case 1: config.stream.width = 960; config.stream.height = 544; break;
+        case 2: config.stream.width = 1280; config.stream.height = 540; break;
+        case 3: config.stream.width = 1280; config.stream.height = 720; break;
+        case 4: config.stream.width = 1920; config.stream.height = 1080; break;
       }
 
       did_change = 1;

--- a/src/gui/ui_settings.c
+++ b/src/gui/ui_settings.c
@@ -412,6 +412,9 @@ enum {
 
 static int SETTINGS_VIEW_IDX[10];
 
+// _countof only works for variable allocated on the stack, not from malloc (sizeof(i) will be incorrect).
+#define _countof(i) (sizeof(i) / sizeof((i)[0]))
+#define _move_idx_in_array(a, f, i) move_idx_in_array((a), _countof(a), (f), (i))
 static int move_idx_in_array(char *array[], int count, char *find, int index_dist) {
   int i = 0;
   for (; i < count; i++) {
@@ -430,6 +433,9 @@ static int move_idx_in_array(char *array[], int count, char *find, int index_dis
   }
 }
 
+#define XSTR(x) STR(x)
+#define STR(x) #x
+
 static int settings_loop(int id, void *context, const input_data *input) {
   menu_entry *menu = context;
   bool did_change = 0;
@@ -447,7 +453,7 @@ static int settings_loop(int id, void *context, const input_data *input) {
       char *resolutions[] = {"960x544", "960x540", "1280x720", "1920x1080", "1280x540"};
       sprintf(current, "%dx%d", config.stream.width, config.stream.height);
 
-      new_idx = move_idx_in_array(resolutions, 7, current, left ? -1 : +1);
+      new_idx = _move_idx_in_array(resolutions, current, left ? -1 : +1);
 
       switch (new_idx) {
         case 0: config.stream.width = 960; config.stream.height = 544; break;
@@ -465,7 +471,7 @@ static int settings_loop(int id, void *context, const input_data *input) {
       }
       char *settings[] = {"30", "60"};
       sprintf(current, "%d", config.stream.fps);
-      new_idx = move_idx_in_array(settings, 2, current, left ? -1 : +1);
+      new_idx = _move_idx_in_array(settings, current, left ? -1 : +1);
 
       switch (new_idx) {
         case 0: config.stream.fps = 30; break;

--- a/src/gui/ui_settings.c
+++ b/src/gui/ui_settings.c
@@ -442,7 +442,7 @@ static int settings_loop(int id, void *context, const input_data *input) {
       if (!left && !right) {
           break;
       }
-      char *resolutions[] = {"960x544", "960x540", "1280x720", "1920x1080", "1280x540", "1680x720", "2560x1080"};
+      char *resolutions[] = {"960x544", "960x540", "1280x720", "1920x1080", "1280x540"};
       sprintf(current, "%dx%d", config.stream.width, config.stream.height);
 
       new_idx = move_idx_in_array(resolutions, 7, current, left ? -1 : +1);
@@ -453,8 +453,6 @@ static int settings_loop(int id, void *context, const input_data *input) {
         case 2: config.stream.width = 1280; config.stream.height = 720; break;
         case 3: config.stream.width = 1920; config.stream.height = 1080; break;
         case 4: config.stream.width = 1280; config.stream.height = 540; break;
-        case 5: config.stream.width = 1680; config.stream.height = 720; break;
-        case 6: config.stream.width = 2560; config.stream.height = 1080; break;
       }
 
       did_change = 1;

--- a/src/gui/ui_settings.c
+++ b/src/gui/ui_settings.c
@@ -384,6 +384,7 @@ enum {
   SETTINGS_JP_LAYOUT,
   SETTINGS_SHOW_FPS,
   SETTINGS_ENABLE_FRAME_PACER,
+  SETTINGS_CENTER_REGION_ONLY,
   SETTINGS_ENABLE_MAPPING,
   SETTINGS_BACK_DEADZONE,
   SETTINGS_SPECIAL_KEYS,
@@ -402,6 +403,7 @@ enum {
   SETTINGS_VIEW_JP_LAYOUT,
   SETTINGS_VIEW_SHOW_FPS,
   SETTINGS_VIEW_ENABLE_FRAME_PACER,
+  SETTINGS_VIEW_CENTER_REGION_ONLY,
   SETTINGS_VIEW_ENABLE_MAPPING,
   SETTINGS_VIEW_BACK_DEADZONE,
   SETTINGS_VIEW_SPECIAL_KEYS,
@@ -544,6 +546,13 @@ static int settings_loop(int id, void *context, const input_data *input) {
       did_change = 1;
       config.enable_frame_pacer = !config.enable_frame_pacer;
       break;
+    case SETTINGS_CENTER_REGION_ONLY:
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
+        break;
+      }
+      did_change = 1;
+      config.center_region_only = !config.center_region_only;
+      break;
     case SETTINGS_ENABLE_MAPPING:
       if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
         break;
@@ -630,6 +639,9 @@ static int settings_loop(int id, void *context, const input_data *input) {
   sprintf(current, "%s", config.enable_frame_pacer ? "yes" : "no");
   MENU_REPLACE(SETTINGS_VIEW_ENABLE_FRAME_PACER, current);
 
+  sprintf(current, "%s", config.center_region_only ? "yes" : "no");
+  MENU_REPLACE(SETTINGS_VIEW_CENTER_REGION_ONLY, current);
+
   sprintf(current, "%s", config.save_debug_log ? "yes" : "no");
   MENU_REPLACE(SETTINGS_VIEW_SAVE_DEBUG_LOG, current);
 
@@ -682,6 +694,7 @@ int ui_settings_menu() {
   MENU_ENTRY(SETTINGS_ENABLE_FRAME_INVAL, SETTINGS_VIEW_ENABLE_FRAME_INVAL, "Enable reference frame invalidation", "");
   MENU_ENTRY(SETTINGS_ENABLE_STREAM_OPTIMIZE, SETTINGS_VIEW_ENABLE_STREAM_OPTIMIZE, "Enable stream optimization", "");
   MENU_ENTRY(SETTINGS_ENABLE_FRAME_PACER, SETTINGS_VIEW_ENABLE_FRAME_PACER, "Enable frame pacer", "");
+  MENU_ENTRY(SETTINGS_CENTER_REGION_ONLY, SETTINGS_VIEW_CENTER_REGION_ONLY, "Display center 16:9 region only", "");
 
   MENU_CATEGORY("System");
   MENU_ENTRY(SETTINGS_SAVE_DEBUG_LOG, SETTINGS_VIEW_SAVE_DEBUG_LOG, "Enable debug log", "");

--- a/src/gui/ui_settings.c
+++ b/src/gui/ui_settings.c
@@ -433,9 +433,6 @@ static int move_idx_in_array(char *array[], int count, char *find, int index_dis
   }
 }
 
-#define XSTR(x) STR(x)
-#define STR(x) #x
-
 static int settings_loop(int id, void *context, const input_data *input) {
   menu_entry *menu = context;
   bool did_change = 0;

--- a/src/input/mapping.c
+++ b/src/input/mapping.c
@@ -108,6 +108,7 @@ void mapping_load(char* fileName, struct mapping* map) {
     }
   }
   free(line);
+  fclose(fd);
 }
 
 void mapping_save(char* fileName, struct mapping* map) {

--- a/src/input/vita.c
+++ b/src/input/vita.c
@@ -79,6 +79,7 @@ typedef struct TouchData {
 #define lerp(value, from_max, to_max) ((((value*10) * (to_max*10))/(from_max*10))/10)
 
 double mouse_multiplier;
+bool drag_active = false;
 
 #define MOUSE_ACTION_DELAY 100000 // 100ms
 
@@ -434,19 +435,24 @@ static inline void vitainput_process(void) {
       front_state = ON_SCREEN_SWIPE;
       break;
     case ON_SCREEN_SWIPE:
-      if (touch.finger > 0) {
-        switch (touch.finger) {
-          case 1:
-            move_mouse(swipe, touch);
-            break;
-          case 2:
-            move_wheel(swipe, touch);
-            break;
-        }
-        memcpy(&swipe, &touch, sizeof(swipe));
-      } else {
-        front_state = NO_TOUCH_ACTION;
+      bool new_drag_status = touch.finger == 3;
+      if (drag_active != new_drag_status) {
+        mouse_click(1, new_drag_status);
+        drag_active = new_drag_status;
       }
+      switch (touch.finger) {
+        case 1:
+        case 3:
+          move_mouse(swipe, touch);
+          break;
+        case 2:
+          move_wheel(swipe, touch);
+          break;
+        default:
+          front_state = NO_TOUCH_ACTION;
+          break;
+      }
+      memcpy(&swipe, &touch, sizeof(swipe));
       break;
   }
 

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -41,6 +41,7 @@
 #define printf vita_debug_log
 #endif
 
+void draw_fps();
 void draw_indicators();
 
 enum {
@@ -408,9 +409,7 @@ static int vita_submit_decode_unit(PDECODE_UNIT decodeUnit) {
       vita2d_start_drawing();
       void *tex_buf = vita2d_texture_get_datap(frame_texture);
       vita2d_draw_texture(frame_texture, 0, 0);
-      if (config.show_fps) {
-        vita2d_font_draw_textf(font, 20, 40, RGBA8(0xFF, 0xFF, 0xFF, 0xFF), 14, "fps: %u / %u", curr_fps[0], curr_fps[1]);
-      }
+      draw_fps();
       draw_indicators();
       vita2d_end_drawing();
       vita2d_wait_rendering_done();
@@ -428,6 +427,12 @@ static int vita_submit_decode_unit(PDECODE_UNIT decodeUnit) {
   //   return DR_NEED_IDR;
 
   return DR_OK;
+}
+
+void draw_fps() {
+  if (config.show_fps) {
+    vita2d_font_draw_textf(font, 40, 20, RGBA8(0xFF, 0xFF, 0xFF, 0xFF), 16, "fps: %u / %u", curr_fps[0], curr_fps[1]);
+  }
 }
 
 void draw_indicators() {

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -55,7 +55,7 @@ enum {
   VITA_VIDEO_ERROR_CREATE_PACER_THREAD  = 0x80010007,
 };
 
-#define DECODER_BUFFER_SIZE 92*1024
+#define DECODER_BUFFER_SIZE(w, h) (92 * 1024) //(4 * w * h)
 
 static char* decoder_buffer = NULL;
 
@@ -220,7 +220,7 @@ static int vita_setup(int videoFormat, int width, int height, int redrawRate, vo
 
   if (video_status == INIT_GS) {
     // INIT_FRAMEBUFFER
-    decoder_buffer = malloc(DECODER_BUFFER_SIZE);
+    decoder_buffer = malloc(DECODER_BUFFER_SIZE(width, height));
     if (decoder_buffer == NULL) {
       printf("not enough memory\n");
       ret = VITA_VIDEO_ERROR_NO_MEM;
@@ -348,6 +348,9 @@ cleanup:
 }
 
 static int vita_submit_decode_unit(PDECODE_UNIT decodeUnit) {
+  unsigned int width = vita2d_texture_get_width(frame_texture);
+  unsigned int height = vita2d_texture_get_height(frame_texture);
+
   SceAvcdecAu au = {0};
   SceAvcdecArrayPicture array_picture = {0};
   struct SceAvcdecPicture picture = {0};
@@ -364,7 +367,7 @@ static int vita_submit_decode_unit(PDECODE_UNIT decodeUnit) {
   picture.frame.frameHeight = SCREEN_HEIGHT;
   picture.frame.pPicture[0] = vita2d_texture_get_datap(frame_texture);
 
-  if (decodeUnit->fullLength >= DECODER_BUFFER_SIZE) {
+  if (decodeUnit->fullLength >= DECODER_BUFFER_SIZE(width, height)) {
     printf("Video decode buffer too small\n");
     exit(1);
   }

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -165,10 +165,12 @@ static void vita_cleanup() {
     sceKernelDeleteThread(pacer_thread);
     video_status--;
   }
+
   if (video_status == INIT_AVC_DEC) {
     sceAvcdecDeleteDecoder(decoder);
     video_status--;
   }
+
   if (video_status == INIT_DECODER_MEMBLOCK) {
     if (decoderblock >= 0) {
       sceKernelFreeMemBlock(decoderblock);
@@ -184,6 +186,7 @@ static void vita_cleanup() {
     }
     video_status--;
   }
+
   if (video_status == INIT_AVC_LIB) {
     sceVideodecTermLibrary(SCE_VIDEODEC_TYPE_HW_AVCDEC);
 
@@ -229,6 +232,7 @@ static int vita_setup(int videoFormat, int width, int height, int redrawRate, vo
     if (!frame_texture) {
       frame_texture = vita2d_create_empty_texture_format(SCREEN_WIDTH, SCREEN_HEIGHT, SCE_GXM_TEXTURE_FORMAT_U8U8U8U8_ABGR);
     }
+
     video_status++;
   }
 
@@ -414,7 +418,9 @@ static int vita_submit_decode_unit(PDECODE_UNIT decodeUnit) {
       vita2d_draw_texture(frame_texture, 0, 0);
       draw_fps();
       draw_indicators();
+      
       vita2d_end_drawing();
+
       vita2d_wait_rendering_done();
       vita2d_swap_buffers();
 

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -156,11 +156,11 @@ static int vita_pacer_thread_main(SceSize args, void *argp) {
 }
 
 static void vita_cleanup() {
-  int ret;
   if (video_status == INIT_FRAME_PACER_THREAD) {
     active_pacer_thread = false;
     // wait 10sec
     SceUInt timeout = 10000000;
+    int ret;
     sceKernelWaitThreadEnd(pacer_thread, &ret, &timeout);
     sceKernelDeleteThread(pacer_thread);
     video_status--;

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -429,11 +429,7 @@ static int vita_submit_decode_unit(PDECODE_UNIT decodeUnit) {
       vita2d_wait_rendering_done();
       vita2d_swap_buffers();
 
-      if (ret < 0) {
-        printf("Failed to sceDisplaySetFrameBuf: 0x%x\n", ret);
-      } else {
-        frame_count++;
-      }
+      frame_count++;
     }
   }
 

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -184,7 +184,7 @@ static void vita_cleanup() {
     video_status--;
   }
   if (video_status == INIT_AVC_LIB) {
-    sceVideodecTermLibrary(0x1001);
+    sceVideodecTermLibrary(SCE_VIDEODEC_TYPE_HW_AVCDEC);
 
     if (init != NULL) {
       free(init);
@@ -253,7 +253,7 @@ static int vita_setup(int videoFormat, int width, int height, int redrawRate, vo
     init->numOfRefFrames = 5;
     init->numOfStreams = 1;
 
-    ret = sceVideodecInitLibrary(0x1001, init);
+    ret = sceVideodecInitLibrary(SCE_VIDEODEC_TYPE_HW_AVCDEC, init);
     if (ret < 0) {
       printf("sceVideodecInitLibrary 0x%x\n", ret);
       ret = VITA_VIDEO_ERROR_INIT_LIB;
@@ -278,7 +278,7 @@ static int vita_setup(int videoFormat, int width, int height, int redrawRate, vo
 
     SceAvcdecDecoderInfo decoder_info_out = {0};
 
-    ret = sceAvcdecQueryDecoderMemSize(0x1001, decoder_info, &decoder_info_out);
+    ret = sceAvcdecQueryDecoderMemSize(SCE_VIDEODEC_TYPE_HW_AVCDEC, decoder_info, &decoder_info_out);
     if (ret < 0) {
       printf("sceAvcdecQueryDecoderMemSize 0x%x size 0x%x\n", ret, decoder_info_out.frameMemSize);
       ret = VITA_VIDEO_ERROR_QUERY_DEC_MEMSIZE;
@@ -316,7 +316,7 @@ static int vita_setup(int videoFormat, int width, int height, int redrawRate, vo
     // INIT_AVC_DEC
     printf("base: 0x%08x\n", decoder->frameBuf.pBuf);
 
-    ret = sceAvcdecCreateDecoder(0x1001, decoder, decoder_info);
+    ret = sceAvcdecCreateDecoder(SCE_VIDEODEC_TYPE_HW_AVCDEC, decoder, decoder_info);
     if (ret < 0) {
       printf("sceAvcdecCreateDecoder 0x%x\n", ret);
       ret = VITA_VIDEO_ERROR_CREATE_DEC;

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -478,6 +478,8 @@ static int vita_submit_decode_unit(PDECODE_UNIT decodeUnit) {
 }
 
 void draw_streaming(vita2d_texture *frame_texture) {
+  // ui is still rendering in the background, clear the screen first
+  vita2d_clear_screen();
   vita2d_draw_texture(frame_texture,
                       image_scaling.origin_x,
                       image_scaling.origin_y);

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -419,7 +419,6 @@ static int vita_submit_decode_unit(PDECODE_UNIT decodeUnit) {
       need_drop--;
     } else {
       vita2d_start_drawing();
-      void *tex_buf = vita2d_texture_get_datap(frame_texture);
       vita2d_draw_texture(frame_texture, 0, 0);
       draw_fps();
       draw_indicators();

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -242,8 +242,12 @@ static int vita_setup(int videoFormat, int width, int height, int redrawRate, vo
       ret = VITA_VIDEO_ERROR_NO_MEM;
       goto cleanup;
     }
-    if (!frame_texture) {
-      frame_texture = vita2d_create_empty_texture_format(SCREEN_WIDTH, SCREEN_HEIGHT, SCE_GXM_TEXTURE_FORMAT_U8U8U8U8_ABGR);
+
+    frame_texture = vita2d_create_empty_texture_format(SCREEN_WIDTH, SCREEN_HEIGHT, SCE_GXM_TEXTURE_FORMAT_U8U8U8U8_ABGR);
+    if (frame_texture == NULL) {
+      printf("not enough memory\n");
+      ret = VITA_VIDEO_ERROR_NO_MEM;
+      goto cleanup;
     }
 
     video_status++;

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -55,7 +55,7 @@ enum {
   VITA_VIDEO_ERROR_CREATE_PACER_THREAD  = 0x80010007,
 };
 
-#define DECODER_BUFFER_SIZE(w, h) (92 * 1024) //(4 * w * h)
+#define DECODER_BUFFER_SIZE (92 * 1024)
 
 static char* decoder_buffer = NULL;
 
@@ -228,7 +228,7 @@ static int vita_setup(int videoFormat, int width, int height, int redrawRate, vo
 
   if (video_status == INIT_GS) {
     // INIT_FRAMEBUFFER
-    decoder_buffer = malloc(DECODER_BUFFER_SIZE(width, height));
+    decoder_buffer = malloc(DECODER_BUFFER_SIZE);
     if (decoder_buffer == NULL) {
       printf("not enough memory\n");
       ret = VITA_VIDEO_ERROR_NO_MEM;
@@ -376,7 +376,7 @@ static int vita_submit_decode_unit(PDECODE_UNIT decodeUnit) {
   picture.frame.frameHeight = SCREEN_HEIGHT;
   picture.frame.pPicture[0] = vita2d_texture_get_datap(frame_texture);
 
-  if (decodeUnit->fullLength >= DECODER_BUFFER_SIZE(width, height)) {
+  if (decodeUnit->fullLength >= DECODER_BUFFER_SIZE) {
     printf("Video decode buffer too small\n");
     exit(1);
   }

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -198,6 +198,11 @@ static void vita_cleanup() {
   }
 
   if (video_status == INIT_FRAMEBUFFER) {
+    if (frame_texture != NULL) {
+      vita2d_free_texture(frame_texture);
+      frame_texture = NULL;
+    }
+
     if (decoder_buffer != NULL) {
       free(decoder_buffer);
       decoder_buffer = NULL;


### PR DESCRIPTION
Major changes in this PR:
- Add a 21:9 resolution (1280x540) to Settings, and reorder the options by display ratio: https://github.com/xyzz/vita-moonlight/commit/a0b12be2e28b33a4b985417e88cfb7fbd2fa16dd, https://github.com/xyzz/vita-moonlight/commit/3772f7fd84d918b14e3ad62a3a260d035923cfe2
  I removed 21:9 720p and 1080p resolution since Vita's decoder cannot accept those specs. However, there is 16:9 1080p listed and my Vita 1000 can't use that option either. Maybe Vita TV can support those so probably need someone else to test this.
- Properly display stream in the correct display ratio, and place in the middle of the screen: https://github.com/xyzz/vita-moonlight/commit/25ff9070a1bc42bf1658192bce5f5f4c64eff330
- Since GFE will add blackbars to the stream even when a non-16:9 monitor is using 16:9 resolution, there is another option to use along the 21:9 resolution to only display the center 16:9 region: https://github.com/xyzz/vita-moonlight/commit/b6b43f6005d99cffef964a640a14e912f4ac8a9f, https://github.com/xyzz/vita-moonlight/commit/176fa9b84affb84d13b08e0dacbd9497053aadf0
  Update: This behavior is only observed when changing resolution through Windows 10's Display Settings, which persists even after reboot. When changing resolution with [ChangeScreenResolution](https://tools.taubenkorb.at/change-screen-resolution/) it behaves properly i.e. no black bar. Feels pretty bad when I found out this program singlehandedly defeated this PR's most purpose...
- Suppress UI rendering when stream is scaled. A proper fix is probably update ```guilib.c``` to use ```connection.c:connection_is_connected()``` to determine whether it should draw the UI element, or let the stream block UI thread. For now I'm just using ```vita2d_clear_screen()``` to clear display buffer: https://github.com/xyzz/vita-moonlight/commit/a928eec4a038cf876e619c8761c8b2350774c798

Minor changes in this PR:
- Remember the currently connected address (internal or external in device.ini), and prioritize that address in the next connection: https://github.com/xyzz/vita-moonlight/commit/97d5739ef7caec0e2cfe6b0ea8b03b9b4a27ca12
  It is ugly but implementing it properly feels like overengineering for only 2 addresses. This helpes me a lot during development so it was included.
- Many minor code fixes: https://github.com/xyzz/vita-moonlight/commit/8e77035372c8904e50531f0b1fd598fb104176d3, https://github.com/xyzz/vita-moonlight/commit/14066260a8762632938f0a57c5369e51af408788, https://github.com/xyzz/vita-moonlight/commit/31189079e3fb5c7e0481c2fc5510e7386ed9824d, https://github.com/xyzz/vita-moonlight/commit/272763b63ee887e54555756cd9dcf27a0fd92a67, https://github.com/xyzz/vita-moonlight/commit/eb64061081198c66ce73657309959f4f34c6053b, https://github.com/xyzz/vita-moonlight/commit/09cd8e8f40582cf77f147738f77273432d0fb129, https://github.com/xyzz/vita-moonlight/commit/92b6f20ce5c7535cc74bb50d001c3ee16c1276cd

I rebased my branch after 0.8.0 release, which is why there are duplicated commits.