### PR TITLE
Improve support for display ratio other than 16:9

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -98,6 +98,8 @@ static int ini_handle(void *out, const char *section, const char *name,
       config->localaudio = BOOL(value);
     } else if (strcmp(name, "enable_frame_pacer") == 0) {
       config->enable_frame_pacer = BOOL(value);
+    } else if (strcmp(name, "center_region_only") == 0) {
+      config->center_region_only = BOOL(value);
     } else if (strcmp(name, "disable_powersave") == 0) {
       config->disable_powersave = BOOL(value);
     } else if (strcmp(name, "jp_layout") == 0) {
@@ -154,6 +156,7 @@ void config_save(const char* filename, PCONFIGURATION config) {
     write_config_string(fd, "app", config->app);
 
   write_config_bool(fd, "enable_frame_pacer", config->enable_frame_pacer);
+  write_config_bool(fd, "center_region_only", config->center_region_only);
   write_config_bool(fd, "disable_powersave", config->disable_powersave);
   write_config_bool(fd, "jp_layout", config->jp_layout);
   write_config_bool(fd, "show_fps", config->show_fps);
@@ -218,6 +221,7 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   config->jp_layout = false;
   config->show_fps = false;
   config->enable_frame_pacer = true;
+  config->center_region_only = false;
 
   config->special_keys.nw = INPUT_SPECIAL_KEY_PAUSE | INPUT_TYPE_SPECIAL;
   config->special_keys.sw = SPECIAL_FLAG | INPUT_TYPE_GAMEPAD;

--- a/src/config.h
+++ b/src/config.h
@@ -63,6 +63,7 @@ typedef struct _CONFIGURATION {
   bool jp_layout;
   bool show_fps;
   bool enable_frame_pacer;
+  bool center_region_only;
   bool save_debug_log;
   struct input_config inputs[MAX_INPUTS];
   int inputsCount;

--- a/src/connection.c
+++ b/src/connection.c
@@ -136,7 +136,7 @@ void connection_stage_complate(int stage) {
   vita_debug_log("connection_stage_complate - stage: %d\n", stage);
 }
 
-void connection_stage_failed(int stage, long code) {
+void connection_stage_failed(int stage, int code) {
   connection_failed_stage = stage;
   connection_failed_stage_code = code;
   vita_debug_log("connection_stage_failed - stage: %d, %d\n", stage, code);
@@ -144,6 +144,10 @@ void connection_stage_failed(int stage, long code) {
 
 bool connection_is_ready() {
   return connection_status != LI_DISCONNECTED;
+}
+
+bool connection_is_connected() {
+  return connection_status == LI_CONNECTED;
 }
 
 int connection_get_status() {

--- a/src/connection.h
+++ b/src/connection.h
@@ -53,4 +53,5 @@ int connection_resume();
 int connection_terminate();
 
 bool connection_is_ready();
+bool connection_is_connected();
 int connection_get_status();

--- a/src/device.c
+++ b/src/device.c
@@ -36,34 +36,42 @@ static void device_file_path(char *out, const char *dir) {
 static int device_ini_handle(void *out, const char *section, const char *name,
                              const char *value) {
   device_info_t *info = out;
+
   if (strcmp(name, "paired") == 0) {
     info->paired = BOOL(value);
   } else if (strcmp(name, "internal") == 0) {
     strncpy(info->internal, value, 255);
   } else if (strcmp(name, "external") == 0) {
     strncpy(info->external, value, 255);
+  } else if (strcmp(name, "prefer_external") == 0) {
+    info->prefer_external = BOOL(value);
   }
   return 1;
 }
 
 device_info_t* append_device(device_info_t *info) {
   if (find_device(info->name)) {
+    vita_debug_log("append_device: device %s is already in the list\n", info->name);
     return NULL;
   }
   // FIXME: need mutex
   if (known_devices.size == 0) {
+    vita_debug_log("append_device: allocating memory for the initial device list...\n");
     known_devices.devices = malloc(sizeof(device_info_t) * 4);
     if (known_devices.devices == NULL) {
+      vita_debug_log("append_device: failed to allocate memory for the initial device list\n");
       return NULL;
     }
     known_devices.size = 4;
   } else if (known_devices.size == known_devices.count) {
+    vita_debug_log("append_device: the device list is full, resizing...\n");
     //if (known_devices.size == 64) {
     //  return false;
     //}
     size_t new_size = sizeof(device_info_t) * (known_devices.size * 2);
     device_info_t *tmp = realloc(known_devices.devices, new_size);
     if (tmp == NULL) {
+      vita_debug_log("append_device: failed to resize the device list\n");
       return NULL;
     }
     known_devices.devices = tmp;
@@ -75,6 +83,8 @@ device_info_t* append_device(device_info_t *info) {
   p->paired = info->paired;
   strncpy(p->internal, info->internal, 255);
   strncpy(p->external, info->external, 255);
+  p->prefer_external = info->prefer_external;
+  vita_debug_log("append_device: device %s is added to the list\n", p->name);
 
   known_devices.count++;
   return p;
@@ -85,10 +95,12 @@ bool update_device(device_info_t *info) {
   if (p == NULL) {
     return false;
   }
+
   //strncpy(p->name, info->name, 255);
   p->paired = info->paired;
   strncpy(p->internal, info->internal, 255);
   strncpy(p->external, info->external, 255);
+  p->prefer_external = info->prefer_external;
   return true;
 }
 
@@ -127,25 +139,47 @@ void load_all_known_devices() {
 bool load_device_info(device_info_t *info) {
   char path[512] = {0};
   device_file_path(path, info->name);
-  vita_debug_log("%s\n", path);
+  vita_debug_log("load_device_info: reading %s\n", path);
 
   int ret = ini_parse(path, device_ini_handle, info);
-  vita_debug_log("%d\n", ret);
-  return ret == 0;
+  if (!ret) {
+    vita_debug_log("load_device_info: device found:\n", ret);
+    vita_debug_log("load_device_info:   info->name = %s\n", info->name);
+    vita_debug_log("load_device_info:   info->paired = %s\n", info->paired ? "true" : "false");
+    vita_debug_log("load_device_info:   info->internal = %s\n", info->internal);
+    vita_debug_log("load_device_info:   info->external = %s\n", info->external);
+    vita_debug_log("load_device_info:   info->prefer_external = %s\n", info->prefer_external ? "true" : "false");
+    return true;
+  } else {
+    vita_debug_log("load_device_info: ini_parse returned %d\n", ret);
+    return false;
+  }
 }
 
 void save_device_info(const device_info_t *info) {
   char path[512] = {0};
   device_file_path(path, info->name);
+  vita_debug_log("save_device_info: device file path: %s\n", path);
 
   FILE* fd = fopen(path, "w");
   if (!fd) {
     // FIXME
+    vita_debug_log("save_device_info: cannot open device file\n");
     return;
   }
 
+  vita_debug_log("save_device_info: paired = %s\n", info->paired ? "true" : "false");
   write_bool(fd, "paired", info->paired);
+
+  vita_debug_log("save_device_info: internal = %s\n", info->internal);
   write_string(fd, "internal", info->internal);
+
+  vita_debug_log("save_device_info: external = %s\n", info->external);
   write_string(fd, "external", info->external);
+
+  vita_debug_log("save_device_info: prefer_external = %s\n", info->prefer_external ? "true" : "false");
+  write_bool(fd, "prefer_external", info->prefer_external);
+
   fclose(fd);
+  vita_debug_log("save_device_info: file closed\n");
 }

--- a/src/device.h
+++ b/src/device.h
@@ -7,6 +7,7 @@ struct device_info {
   bool paired;
   char internal[256];
   char external[256];
+  bool prefer_external;
 };
 
 typedef struct device_infos device_infos_t;

--- a/src/gui/ime.c
+++ b/src/gui/ime.c
@@ -50,7 +50,7 @@ void utf16_to_utf8(uint16_t *src, uint8_t *dst) {
   *dst = '\0';
 }
 
-void utf8_to_utf16(uint8_t *src, uint16_t *dst) {
+void utf8_to_utf16(const uint8_t *src, uint16_t *dst) {
   int i;
   for (i = 0; src[i];) {
     if ((src[i] & 0xE0) == 0xE0) {
@@ -68,10 +68,10 @@ void utf8_to_utf16(uint8_t *src, uint16_t *dst) {
   *dst = '\0';
 }
 
-void initImeDialog(SceImeType type, char *title, char *initial_text, int max_text_length) {
+void initImeDialog(SceImeType type, const char *title, char *initial_text, int max_text_length) {
   // Convert UTF8 to UTF16
-  utf8_to_utf16((uint8_t *)title, ime_title_utf16);
-  utf8_to_utf16((uint8_t *)initial_text, ime_initial_text_utf16);
+  utf8_to_utf16((const uint8_t *)title, ime_title_utf16);
+  utf8_to_utf16((const uint8_t *)initial_text, ime_initial_text_utf16);
 
   SceImeDialogParam param;
   sceImeDialogParamInit(&param);

--- a/src/gui/ui.c
+++ b/src/gui/ui.c
@@ -144,7 +144,7 @@ int global_loop(int cursor, void *ctx, const input_data *input) {
       sceKernelDelayThread(500 * 1000);
       connection_resume();
 
-      while (connection_get_status() == LI_CONNECTED) {
+      while (connection_is_connected()) {
         sceKernelDelayThread(500 * 1000);
       }
     }

--- a/src/gui/ui_connect.c
+++ b/src/gui/ui_connect.c
@@ -208,7 +208,7 @@ int ui_connect_loop(int id, void *context, const input_data *input) {
       }
 
 mainloop:
-      while (connection_get_status() == LI_CONNECTED) {
+      while (connection_is_connected()) {
         sceKernelDelayThread(500 * 1000);
       }
 

--- a/src/gui/ui_connect.c
+++ b/src/gui/ui_connect.c
@@ -188,6 +188,7 @@ int ui_connect_loop(int id, void *context, const input_data *input) {
       display_error("Quitting failed: %d", ret);
       return 0;
 
+    // application launcher / resume
     default:
       vitapower_config(config);
       vitainput_config(config);
@@ -474,19 +475,27 @@ void ui_connect_paired_device(device_info_t *info) {
     display_error("Unpaired device\n%s", info->name);
     return;
   }
+
   char *addr = NULL;
-  if (info->internal && check_connection(info->name, info->internal)) {
+  if (info->prefer_external && info->external && check_connection(info->name, info->external)) {
+    addr = info->external;
+  } else if (info->internal && check_connection(info->name, info->internal)) {
     addr = info->internal;
   } else if (info->external && check_connection(info->name, info->external)) {
     addr = info->external;
   }
+  info->prefer_external = addr == info->external;
+  save_device_info(info);
+  
   if (addr == NULL) {
     display_error("Can't connect to server\n%s", info->name);
     return;
   }
+
   if (!ui_connect(info->name, addr)) {
     return;
   }
+
   while (ui_connected_menu() == QUIT_RELOAD);
 }
 

--- a/src/gui/ui_device.c
+++ b/src/gui/ui_device.c
@@ -208,7 +208,7 @@ static int ui_search_device_callback(int id, void *context, const input_data *in
       return 0;
     }
 
-    uint32_t extern_addr = 0;
+    unsigned int extern_addr = 0;
     if (LiFindExternalAddressIP4("stun.stunprotocol.org", 3478, &extern_addr) == 0) {
       struct sockaddr_in addr;
       addr.sin_family = AF_INET;

--- a/src/gui/ui_settings.c
+++ b/src/gui/ui_settings.c
@@ -410,6 +410,9 @@ enum {
 
 static int SETTINGS_VIEW_IDX[10];
 
+// _countof only works for variable allocated on the stack, not from malloc (sizeof(i) will be incorrect).
+#define _countof(i) (sizeof(i) / sizeof((i)[0]))
+#define _move_idx_in_array(a, f, i) move_idx_in_array((a), _countof(a), (f), (i))
 static int move_idx_in_array(char *array[], int count, char *find, int index_dist) {
   int i = 0;
   for (; i < count; i++) {
@@ -445,7 +448,7 @@ static int settings_loop(int id, void *context, const input_data *input) {
       char *resolutions[] = {"960x540", "960x544", "1280x720", "1920x1080"};
       sprintf(current, "%dx%d", config.stream.width, config.stream.height);
 
-      new_idx = move_idx_in_array(resolutions, 4, current, left ? -1 : +1);
+      new_idx = _move_idx_in_array(resolutions, current, left ? -1 : +1);
 
       switch (new_idx) {
         case 0: config.stream.width = 960; config.stream.height = 540; break;
@@ -462,7 +465,7 @@ static int settings_loop(int id, void *context, const input_data *input) {
       }
       char *settings[] = {"30", "60"};
       sprintf(current, "%d", config.stream.fps);
-      new_idx = move_idx_in_array(settings, 2, current, left ? -1 : +1);
+      new_idx = _move_idx_in_array(settings, current, left ? -1 : +1);
 
       switch (new_idx) {
         case 0: config.stream.fps = 30; break;

--- a/src/gui/ui_settings.c
+++ b/src/gui/ui_settings.c
@@ -447,7 +447,7 @@ static int settings_loop(int id, void *context, const input_data *input) {
       if (!left && !right) {
           break;
       }
-      char *resolutions[] = {"960x540", "960x544", "1280x720", "1920x1080"};
+      char *resolutions[] = {"960x540", "960x544", "1280x540", "1280x720", "1920x1080"};
       sprintf(current, "%dx%d", config.stream.width, config.stream.height);
 
       new_idx = _move_idx_in_array(resolutions, current, left ? -1 : +1);
@@ -455,8 +455,9 @@ static int settings_loop(int id, void *context, const input_data *input) {
       switch (new_idx) {
         case 0: config.stream.width = 960; config.stream.height = 540; break;
         case 1: config.stream.width = 960; config.stream.height = 544; break;
-        case 2: config.stream.width = 1280; config.stream.height = 720; break;
-        case 3: config.stream.width = 1920; config.stream.height = 1080; break;
+        case 2: config.stream.width = 1280; config.stream.height = 540; break;
+        case 3: config.stream.width = 1280; config.stream.height = 720; break;
+        case 4: config.stream.width = 1920; config.stream.height = 1080; break;
       }
 
       did_change = 1;

--- a/src/gui/ui_settings.c
+++ b/src/gui/ui_settings.c
@@ -384,6 +384,7 @@ enum {
   SETTINGS_JP_LAYOUT,
   SETTINGS_SHOW_FPS,
   SETTINGS_ENABLE_FRAME_PACER,
+  SETTINGS_CENTER_REGION_ONLY,
   SETTINGS_ENABLE_MAPPING,
   SETTINGS_BACK_DEADZONE,
   SETTINGS_SPECIAL_KEYS,
@@ -402,6 +403,7 @@ enum {
   SETTINGS_VIEW_JP_LAYOUT,
   SETTINGS_VIEW_SHOW_FPS,
   SETTINGS_VIEW_ENABLE_FRAME_PACER,
+  SETTINGS_VIEW_CENTER_REGION_ONLY,
   SETTINGS_VIEW_ENABLE_MAPPING,
   SETTINGS_VIEW_BACK_DEADZONE,
   SETTINGS_VIEW_SPECIAL_KEYS,
@@ -546,6 +548,13 @@ static int settings_loop(int id, void *context, const input_data *input) {
       did_change = 1;
       config.enable_frame_pacer = !config.enable_frame_pacer;
       break;
+    case SETTINGS_CENTER_REGION_ONLY:
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
+        break;
+      }
+      did_change = 1;
+      config.center_region_only = !config.center_region_only;
+      break;
     case SETTINGS_ENABLE_MAPPING:
       if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
         break;
@@ -631,6 +640,9 @@ static int settings_loop(int id, void *context, const input_data *input) {
 
   sprintf(current, "%s", config.enable_frame_pacer ? "yes" : "no");
   MENU_REPLACE(SETTINGS_VIEW_ENABLE_FRAME_PACER, current);
+
+  sprintf(current, "%s", config.center_region_only ? "yes" : "no");
+  MENU_REPLACE(SETTINGS_VIEW_CENTER_REGION_ONLY, current);
 
   sprintf(current, "%s", config.save_debug_log ? "yes" : "no");
   MENU_REPLACE(SETTINGS_VIEW_SAVE_DEBUG_LOG, current);

--- a/src/input/mapping.c
+++ b/src/input/mapping.c
@@ -108,6 +108,7 @@ void mapping_load(char* fileName, struct mapping* map) {
     }
   }
   free(line);
+  fclose(fd);
 }
 
 void mapping_save(char* fileName, struct mapping* map) {

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -54,7 +54,7 @@ enum {
   VITA_VIDEO_ERROR_CREATE_PACER_THREAD  = 0x80010007,
 };
 
-#define DECODER_BUFFER_SIZE 92*1024
+#define DECODER_BUFFER_SIZE (92 * 1024)
 
 static char* decoder_buffer = NULL;
 
@@ -184,7 +184,7 @@ static void vita_cleanup() {
     video_status--;
   }
   if (video_status == INIT_AVC_LIB) {
-    sceVideodecTermLibrary(0x1001);
+    sceVideodecTermLibrary(SCE_VIDEODEC_TYPE_HW_AVCDEC);
 
     if (init != NULL) {
       free(init);
@@ -253,7 +253,7 @@ static int vita_setup(int videoFormat, int width, int height, int redrawRate, vo
     init->numOfRefFrames = 5;
     init->numOfStreams = 1;
 
-    ret = sceVideodecInitLibrary(0x1001, init);
+    ret = sceVideodecInitLibrary(SCE_VIDEODEC_TYPE_HW_AVCDEC, init);
     if (ret < 0) {
       printf("sceVideodecInitLibrary 0x%x\n", ret);
       ret = VITA_VIDEO_ERROR_INIT_LIB;
@@ -278,7 +278,7 @@ static int vita_setup(int videoFormat, int width, int height, int redrawRate, vo
 
     SceAvcdecDecoderInfo decoder_info_out = {0};
 
-    ret = sceAvcdecQueryDecoderMemSize(0x1001, decoder_info, &decoder_info_out);
+    ret = sceAvcdecQueryDecoderMemSize(SCE_VIDEODEC_TYPE_HW_AVCDEC, decoder_info, &decoder_info_out);
     if (ret < 0) {
       printf("sceAvcdecQueryDecoderMemSize 0x%x size 0x%x\n", ret, decoder_info_out.frameMemSize);
       ret = VITA_VIDEO_ERROR_QUERY_DEC_MEMSIZE;
@@ -316,7 +316,7 @@ static int vita_setup(int videoFormat, int width, int height, int redrawRate, vo
     // INIT_AVC_DEC
     printf("base: 0x%08x\n", decoder->frameBuf.pBuf);
 
-    ret = sceAvcdecCreateDecoder(0x1001, decoder, decoder_info);
+    ret = sceAvcdecCreateDecoder(SCE_VIDEODEC_TYPE_HW_AVCDEC, decoder, decoder_info);
     if (ret < 0) {
       printf("sceAvcdecCreateDecoder 0x%x\n", ret);
       ret = VITA_VIDEO_ERROR_CREATE_DEC;

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 
 #include <stdarg.h>
 
@@ -41,6 +42,7 @@
 #define printf vita_debug_log
 #endif
 
+void draw_streaming(vita2d_texture *frame_texture);
 void draw_fps();
 void draw_indicators();
 
@@ -103,6 +105,83 @@ uint32_t need_drop = 0;
 uint32_t curr_fps[2] = {0, 0};
 float carry = 0;
 
+typedef struct {
+  unsigned int texture_width;
+  unsigned int texture_height;
+  float origin_x;
+  float origin_y;
+  float region_x1;
+  float region_y1;
+  float region_x2;
+  float region_y2;
+} image_scaling_settings;
+
+static image_scaling_settings image_scaling = {0};
+
+// Vita's sceVideodecInitLibrary only accept resolution that is multiple of 16 on either dimension,
+// and the smallest resolution is 64
+// Full supported resolution list can be found at:
+// https://github.com/MakiseKurisu/vita-sceVideodecInitLibrary-test/
+#define ROUND_NEAREST_16(x)                     (round(((double) (x)) / 16) * 16)
+#define VITA_DECODER_RESOLUTION_LOWER_BOUND(x)  ((x) < 64 ? 64 : (x))
+#define VITA_DECODER_RESOLUTION(x)              (VITA_DECODER_RESOLUTION_LOWER_BOUND(ROUND_NEAREST_16(x)))
+
+void update_scaling_settings(int width, int height) {
+  image_scaling.texture_width = SCREEN_WIDTH;
+  image_scaling.texture_height = SCREEN_HEIGHT;
+  image_scaling.origin_x = 0;
+  image_scaling.origin_y = 0;
+  image_scaling.region_x1 = 0;
+  image_scaling.region_y1 = 0;
+  image_scaling.region_x2 = image_scaling.texture_width;
+  image_scaling.region_y2 = image_scaling.texture_height;
+
+  double scaled_width = (double) SCREEN_HEIGHT * width / height;
+  double scaled_height = (double) SCREEN_WIDTH * height / width;
+
+  if (SCREEN_WIDTH * height == SCREEN_HEIGHT * width) {
+    // streaming resolution ratio matches Vita's screen ratio
+    // use default setting
+  } else if (SCREEN_WIDTH * height > SCREEN_HEIGHT * width) {
+    // host ratio example: 4:3, 16:10
+    // Vita ratio range: 2:16 (64 x 544) - native (960 x 544)
+    if (config.center_region_only) {
+      image_scaling.texture_height = VITA_DECODER_RESOLUTION(scaled_height);
+      image_scaling.region_y1 = VITA_DECODER_RESOLUTION((scaled_height - SCREEN_HEIGHT) / 2);
+      image_scaling.region_y2 = VITA_DECODER_RESOLUTION((scaled_height + SCREEN_HEIGHT) / 2);
+    } else {
+      image_scaling.texture_width = VITA_DECODER_RESOLUTION(scaled_width);
+      image_scaling.region_x2 = VITA_DECODER_RESOLUTION(scaled_width);
+      image_scaling.origin_x = round((double) (SCREEN_WIDTH - image_scaling.texture_width) / 2);
+    }
+  } else {
+    // host ratio example: 16:9, 21:9, 32:9
+    // Vita ratio range: native (960 x 544) - 15:1 (960 x 64)
+    if (config.center_region_only) {
+      image_scaling.texture_width = VITA_DECODER_RESOLUTION(scaled_width);
+      image_scaling.region_x1 = VITA_DECODER_RESOLUTION((scaled_width - SCREEN_WIDTH) / 2);
+      image_scaling.region_x2 = VITA_DECODER_RESOLUTION((scaled_width + SCREEN_WIDTH) / 2);
+    } else {
+      image_scaling.texture_height = VITA_DECODER_RESOLUTION(scaled_height);
+      image_scaling.region_y2 = VITA_DECODER_RESOLUTION(scaled_height);
+      image_scaling.origin_y = round((double) (SCREEN_HEIGHT - image_scaling.texture_height) / 2);
+    }
+  }
+
+  printf("update_scaling_settings: width = %u\n", width);
+  printf("update_scaling_settings: height = %u\n", height);
+  printf("update_scaling_settings: scaled_width = %f\n", scaled_width);
+  printf("update_scaling_settings: scaled_height = %f\n", scaled_height);
+  printf("update_scaling_settings: image_scaling.texture_width = %u\n", image_scaling.texture_width);
+  printf("update_scaling_settings: image_scaling.texture_height = %u\n", image_scaling.texture_height);
+  printf("update_scaling_settings: image_scaling.origin_x = %f\n", image_scaling.origin_x);
+  printf("update_scaling_settings: image_scaling.origin_y = %f\n", image_scaling.origin_y);
+  printf("update_scaling_settings: image_scaling.region_x1 = %f\n", image_scaling.region_x1);
+  printf("update_scaling_settings: image_scaling.region_y1 = %f\n", image_scaling.region_y1);
+  printf("update_scaling_settings: image_scaling.region_x2 = %f\n", image_scaling.region_x2);
+  printf("update_scaling_settings: image_scaling.region_y2 = %f\n", image_scaling.region_y2);
+}
+
 static int vita_pacer_thread_main(SceSize args, void *argp) {
   // 1s
   int wait = 1000000;
@@ -156,19 +235,21 @@ static int vita_pacer_thread_main(SceSize args, void *argp) {
 }
 
 static void vita_cleanup() {
-  int ret;
   if (video_status == INIT_FRAME_PACER_THREAD) {
     active_pacer_thread = false;
     // wait 10sec
     SceUInt timeout = 10000000;
+    int ret;
     sceKernelWaitThreadEnd(pacer_thread, &ret, &timeout);
     sceKernelDeleteThread(pacer_thread);
     video_status--;
   }
+
   if (video_status == INIT_AVC_DEC) {
     sceAvcdecDeleteDecoder(decoder);
     video_status--;
   }
+
   if (video_status == INIT_DECODER_MEMBLOCK) {
     if (decoderblock >= 0) {
       sceKernelFreeMemBlock(decoderblock);
@@ -184,6 +265,7 @@ static void vita_cleanup() {
     }
     video_status--;
   }
+
   if (video_status == INIT_AVC_LIB) {
     sceVideodecTermLibrary(SCE_VIDEODEC_TYPE_HW_AVCDEC);
 
@@ -195,6 +277,11 @@ static void vita_cleanup() {
   }
 
   if (video_status == INIT_FRAMEBUFFER) {
+    if (frame_texture != NULL) {
+      vita2d_free_texture(frame_texture);
+      frame_texture = NULL;
+    }
+
     if (decoder_buffer != NULL) {
       free(decoder_buffer);
       decoder_buffer = NULL;
@@ -220,15 +307,22 @@ static int vita_setup(int videoFormat, int width, int height, int redrawRate, vo
 
   if (video_status == INIT_GS) {
     // INIT_FRAMEBUFFER
+    update_scaling_settings(width, height);
+
     decoder_buffer = malloc(DECODER_BUFFER_SIZE);
     if (decoder_buffer == NULL) {
       printf("not enough memory\n");
       ret = VITA_VIDEO_ERROR_NO_MEM;
       goto cleanup;
     }
-    if (!frame_texture) {
-      frame_texture = vita2d_create_empty_texture_format(SCREEN_WIDTH, SCREEN_HEIGHT, SCE_GXM_TEXTURE_FORMAT_U8U8U8U8_ABGR);
+
+    frame_texture = vita2d_create_empty_texture_format(image_scaling.texture_width, image_scaling.texture_height, SCE_GXM_TEXTURE_FORMAT_U8U8U8U8_ABGR);
+    if (frame_texture == NULL) {
+      printf("not enough memory\n");
+      ret = VITA_VIDEO_ERROR_NO_MEM;
+      goto cleanup;
     }
+
     video_status++;
   }
 
@@ -243,14 +337,8 @@ static int vita_setup(int videoFormat, int width, int height, int redrawRate, vo
       }
     }
     init->size = sizeof(SceVideodecQueryInitInfoHwAvcdec);
-    init->horizontal = width;
-    init->vertical = height;
-    // XXX: specialized setup for 960x540
-    // when we pass just 960x540 instead 960x544, sceVideodecInitLibrary
-    // would be failed
-    if (width == 960 && height == 540) {
-      init->vertical = 544;
-    }
+    init->horizontal = VITA_DECODER_RESOLUTION(width);
+    init->vertical = VITA_DECODER_RESOLUTION(height);
     init->numOfRefFrames = 5;
     init->numOfStreams = 1;
 
@@ -359,9 +447,9 @@ static int vita_submit_decode_unit(PDECODE_UNIT decodeUnit) {
 
   picture.size = sizeof(picture);
   picture.frame.pixelType = 0;
-  picture.frame.framePitch = LINE_SIZE;
-  picture.frame.frameWidth = SCREEN_WIDTH;
-  picture.frame.frameHeight = SCREEN_HEIGHT;
+  picture.frame.framePitch = image_scaling.texture_width;
+  picture.frame.frameWidth = image_scaling.texture_width;
+  picture.frame.frameHeight = image_scaling.texture_height;
   picture.frame.pPicture[0] = vita2d_texture_get_datap(frame_texture);
 
   if (decodeUnit->fullLength >= DECODER_BUFFER_SIZE) {
@@ -407,19 +495,17 @@ static int vita_submit_decode_unit(PDECODE_UNIT decodeUnit) {
       need_drop--;
     } else {
       vita2d_start_drawing();
-      void *tex_buf = vita2d_texture_get_datap(frame_texture);
-      vita2d_draw_texture(frame_texture, 0, 0);
+      
+      draw_streaming(frame_texture);
       draw_fps();
       draw_indicators();
+      
       vita2d_end_drawing();
+
       vita2d_wait_rendering_done();
       vita2d_swap_buffers();
 
-      if (ret < 0) {
-        printf("Failed to sceDisplaySetFrameBuf: 0x%x\n", ret);
-      } else {
-        frame_count++;
-      }
+      frame_count++;
     }
   }
 
@@ -427,6 +513,18 @@ static int vita_submit_decode_unit(PDECODE_UNIT decodeUnit) {
   //   return DR_NEED_IDR;
 
   return DR_OK;
+}
+
+void draw_streaming(vita2d_texture *frame_texture) {
+  // ui is still rendering in the background, clear the screen first
+  vita2d_clear_screen();
+  vita2d_draw_texture_part(frame_texture,
+                           image_scaling.origin_x,
+                           image_scaling.origin_y,
+                           image_scaling.region_x1,
+                           image_scaling.region_y1,
+                           image_scaling.region_x2,
+                           image_scaling.region_y2);
 }
 
 void draw_fps() {

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -41,6 +41,7 @@
 #define printf vita_debug_log
 #endif
 
+void draw_fps();
 void draw_indicators();
 
 enum {
@@ -408,9 +409,7 @@ static int vita_submit_decode_unit(PDECODE_UNIT decodeUnit) {
       vita2d_start_drawing();
       void *tex_buf = vita2d_texture_get_datap(frame_texture);
       vita2d_draw_texture(frame_texture, 0, 0);
-      if (config.show_fps) {
-        vita2d_font_draw_textf(font, 20, 40, RGBA8(0xFF, 0xFF, 0xFF, 0xFF), 14, "fps: %u / %u", curr_fps[0], curr_fps[1]);
-      }
+      draw_fps();
       draw_indicators();
       vita2d_end_drawing();
       vita2d_wait_rendering_done();
@@ -428,6 +427,12 @@ static int vita_submit_decode_unit(PDECODE_UNIT decodeUnit) {
   //   return DR_NEED_IDR;
 
   return DR_OK;
+}
+
+void draw_fps() {
+  if (config.show_fps) {
+    vita2d_font_draw_textf(font, 40, 20, RGBA8(0xFF, 0xFF, 0xFF, 0xFF), 16, "fps: %u / %u", curr_fps[0], curr_fps[1]);
+  }
 }
 
 void draw_indicators() {


### PR DESCRIPTION
Changes in this PR:
- Remember the currently connected address (internal or external in device.ini), and prioritize that address in the next connection: https://github.com/xyzz/vita-moonlight/commit/7998108c02e4d76a24055af3a7ec2cf1d4d08d6b
- Add a 21:9 resolution (1280x540) to Settings: https://github.com/xyzz/vita-moonlight/commit/f1eb93169dca4ce05fad9e5a00c8548d4ed0ad7b
- Properly display stream in the correct display ratio, and place in the middle of the screen: https://github.com/xyzz/vita-moonlight/commit/14e3a2c06383bbc1204b0b4d41a582112f85c85c
- Since GFE will add blackbars to the stream even when a non-16:9 monitor is using 16:9 resolution, there is another option to use along the 21:9 resolution to only display the center 16:9 region: https://github.com/xyzz/vita-moonlight/commit/5b7a2ccf27be1968bd1eebbf4ee9b01c670d6867
- Also some fixes on compiler warning, hardcoded value, missing fclose, etc: https://github.com/xyzz/vita-moonlight/commit/58aae13a362b6f8c094e58ef21edd34a65b632c2