### PR TITLE
Implement 3-finger drag

### DIFF
--- a/src/input/vita.c
+++ b/src/input/vita.c
@@ -79,6 +79,7 @@ typedef struct TouchData {
 #define lerp(value, from_max, to_max) ((((value*10) * (to_max*10))/(from_max*10))/10)
 
 double mouse_multiplier;
+bool drag_active = false;
 
 #define MOUSE_ACTION_DELAY 100000 // 100ms
 
@@ -396,6 +397,7 @@ static inline void vitainput_process(void) {
           is_old_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_SE));
 
   // mouse
+  bool new_drag_status = touch.finger == 3;
   switch (front_state) {
     case NO_TOUCH_ACTION:
       if (touch.finger > 0) {
@@ -434,19 +436,23 @@ static inline void vitainput_process(void) {
       front_state = ON_SCREEN_SWIPE;
       break;
     case ON_SCREEN_SWIPE:
-      if (touch.finger > 0) {
-        switch (touch.finger) {
-          case 1:
-            move_mouse(swipe, touch);
-            break;
-          case 2:
-            move_wheel(swipe, touch);
-            break;
-        }
-        memcpy(&swipe, &touch, sizeof(swipe));
-      } else {
-        front_state = NO_TOUCH_ACTION;
+      if (drag_active != new_drag_status) {
+        mouse_click(1, new_drag_status);
+        drag_active = new_drag_status;
       }
+      switch (touch.finger) {
+        case 1:
+        case 3:
+          move_mouse(swipe, touch);
+          break;
+        case 2:
+          move_wheel(swipe, touch);
+          break;
+        default:
+          front_state = NO_TOUCH_ACTION;
+          break;
+      }
+      memcpy(&swipe, &touch, sizeof(swipe));
       break;
   }
 


### PR DESCRIPTION
Some games will spawn a non full-screen, fixed size launcher before the main game starts. This launcher is typically an updater and/or a login authenticator. When streaming in low resolution (for example in Vita's native resolution). some UI elements will not be visible until the window is moved, since the size of the window is larger than the streaming resolution.

This PR implements a 3-finger drag gesture to workaround this issue.

I'll likely work on the touchscreen support with LiSendMousePositionEvent next.