### PR TITLE
Add more fps modes

### DIFF
--- a/src/gui/ui_settings.c
+++ b/src/gui/ui_settings.c
@@ -512,13 +512,16 @@ static int settings_loop(int id, void *context, const input_data *input) {
       if (!left && !right) {
           break;
       }
-      char *settings[] = {"30", "60"};
+      char *settings[] = {"24", "30", "40", "50", "60"};
       sprintf(current, "%d", config.stream.fps);
       new_idx = _move_idx_in_array(settings, current, left ? -1 : +1);
 
       switch (new_idx) {
-        case 0: config.stream.fps = 30; break;
-        case 1: config.stream.fps = 60; break;
+        case 0: config.stream.fps = 24; break; // Movies
+        case 1: config.stream.fps = 30; break;
+        case 2: config.stream.fps = 40; break;
+        case 3: config.stream.fps = 50; break; // PAL
+        case 4: config.stream.fps = 60; break; // NTSC
       }
 
       did_change = 1;

--- a/src/video/vita.c
+++ b/src/video/vita.c
@@ -210,7 +210,7 @@ static int vita_pacer_thread_main(SceSize args, void *argp) {
     }
 
     curr_fps[0] = curr_frame_count;
-    curr_fps[1] = vblank_fps;
+    curr_fps[1] = max_fps;
 
     last_vblank_count = curr_vblank_count;
     uint64_t curr_check_time = sceKernelGetSystemTimeWide();


### PR DESCRIPTION
(I tried the squash again and this time it works)

Small pr to add 24, 40 and 50 fps config modes to save bandwidth.

I changed the fps counter too, instead of showing 60 as the maximum framerate, the counter shows stream's target fps.
To have 40/40 instead of 40/60 at screen.