### PR TITLE
feature upgrades: PS button capture, allow using touch zones with touch enabled; minor bugfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ target_link_libraries(${PROJECT_NAME}.elf
 	-lScePower_stub
 	-lSceVideodec_stub
 	-lSceCommonDialog_stub
-  -lSceShellSvc_stub
+	-lSceShellSvc_stub
 	-lSceAppMgr_stub
 	-lSceAudio_stub
 	-lSceIme_stub
@@ -191,8 +191,8 @@ add_custom_target(${PROJECT_NAME}.velf ALL
 	COMMAND vita-elf-create ${PROJECT_NAME}.elf ${PROJECT_NAME}.velf
 )
 
-add_custom_target(param.sfo ALL
-  COMMAND vita-mksfoex -s TITLE_ID=${TITLE_ID} -s APP_VER=${APP_VER} "${TITLE}" param.sfo
+add_custom_target(param.sfo ALL   
+	COMMAND vita-mksfoex -s TITLE_ID=${TITLE_ID} -s APP_VER=${APP_VER} "${TITLE}" param.sfo
 )
 
 # Actualizar versión en template.xml automáticamente antes de empaquetar el VPK (solo la línea visual)
@@ -202,7 +202,7 @@ add_custom_target(update_template_version ALL
 )
 
 add_custom_target(${PROJECT_NAME}.vpk ALL
-  COMMAND vita-make-fself -a 0x2800000000000001 -at 0x0E -c ${PROJECT_NAME}.velf eboot.bin
+	COMMAND vita-make-fself -a 0x2800000000000001 -at 0x0E -c ${PROJECT_NAME}.velf eboot.bin
 	COMMAND vita-pack-vpk -s param.sfo -b eboot.bin
 			--add ../sce_sys/icon0.png=sce_sys/icon0.png
 			--add ../sce_sys/livearea/contents/bg.png=sce_sys/livearea/contents/bg.png

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ include("$ENV{VITASDK}/share/vita.cmake" REQUIRED)
 #   set(VERSION_MINOR "11")
 #   set(VERSION_PATCH "2")
 #
-
 set(TITLE_ID "XYZZ00002")
 set(TITLE "Moonlight")
 set(VERSION_MAJOR "0")
@@ -171,6 +170,7 @@ target_link_libraries(${PROJECT_NAME}.elf
 	-lScePower_stub
 	-lSceVideodec_stub
 	-lSceCommonDialog_stub
+  -lSceShellSvc_stub
 	-lSceAppMgr_stub
 	-lSceAudio_stub
 	-lSceIme_stub
@@ -192,7 +192,7 @@ add_custom_target(${PROJECT_NAME}.velf ALL
 )
 
 add_custom_target(param.sfo ALL
-	COMMAND vita-mksfoex -s TITLE_ID=${TITLE_ID} -s APP_VER=${APP_VER} "${TITLE}" param.sfo
+  COMMAND vita-mksfoex -s TITLE_ID=${TITLE_ID} -s APP_VER=${APP_VER} "${TITLE}" param.sfo
 )
 
 # Actualizar versión en template.xml automáticamente antes de empaquetar el VPK (solo la línea visual)
@@ -202,7 +202,7 @@ add_custom_target(update_template_version ALL
 )
 
 add_custom_target(${PROJECT_NAME}.vpk ALL
-	COMMAND vita-make-fself -s -c ${PROJECT_NAME}.velf eboot.bin
+  COMMAND vita-make-fself -a 0x2800000000000001 -at 0x0E -c ${PROJECT_NAME}.velf eboot.bin
 	COMMAND vita-pack-vpk -s param.sfo -b eboot.bin
 			--add ../sce_sys/icon0.png=sce_sys/icon0.png
 			--add ../sce_sys/livearea/contents/bg.png=sce_sys/livearea/contents/bg.png

--- a/makefast
+++ b/makefast
@@ -27,8 +27,8 @@ if [ -z "$TITLEID" ]; then
 fi
 echo "[makefast] TITLEID: $TITLEID"
 
-BUILD_DIR="cmake-build-psv"
-BIN_FILE="moonlight_vita.self"
+BUILD_DIR="build"
+BIN_FILE="eboot.bin"
 EBOOT_FILE="eboot.bin"
 
 # Permitir argumentos: ./makefast <build_dir> <archivo>
@@ -42,13 +42,43 @@ fi
 SELF_PATH="${BUILD_DIR}/${BIN_FILE}"
 EBOOT_PATH="${BUILD_DIR}/${EBOOT_FILE}"
 
-echo "[makefast] Verificando existencia de $SELF_PATH..."
-if [ ! -f "$SELF_PATH" ]; then
-    echo "[makefast] Error: No se encontró $SELF_PATH. Compila primero."
+# Preferir el eboot dentro del build dir. Si no existe allí, buscar en build/ el archivo más reciente
+echo "[makefast] Buscando eboot: preferir $SELF_PATH..."
+if [ -f "$SELF_PATH" ]; then
+    SELECTED_EBOOT="$SELF_PATH"
+elif [[ "$BIN_FILE" == */* ]] && [ -f "$BIN_FILE" ]; then
+    # If BIN_FILE includes a path (absolute/relative) and file exists, use it
+    echo "[makefast] Se proporcionó un path para eboot: $BIN_FILE, usando $BIN_FILE"
+    SELECTED_EBOOT="$BIN_FILE"
+else
+    # buscar en build/ el archivo más reciente con el mismo nombre
+    SELECTED_EBOOT=$(find "$BUILD_DIR" -maxdepth 2 -type f -name "$BIN_FILE" -printf '%T@ %p\n' 2>/dev/null | sort -nr | awk '{print $2; exit}')
+    if [ -n "$SELECTED_EBOOT" ]; then
+        echo "[makefast] Usando $SELECTED_EBOOT (en $BUILD_DIR)."
+    else
+        # buscar en el repo completo (excluyendo build/.git etc.) y tomar el más reciente
+        echo "[makefast] No se encontró $BIN_FILE en $BUILD_DIR, buscando en el repo..."
+        SELECTED_EBOOT=$(find . -maxdepth 4 -type f -name "$BIN_FILE" -printf '%T@ %p\n' 2>/dev/null | sort -nr | awk '{$1=""; sub(/^ /, ""); print; exit}')
+        if [ -n "$SELECTED_EBOOT" ]; then
+            echo "[makefast] Usando $SELECTED_EBOOT (fallback repo)."
+        fi
+    fi
+fi
+
+if [ -z "$SELECTED_EBOOT" ]; then
+    echo "[makefast] Error: No se encontró ningún $BIN_FILE (ni en $BUILD_DIR ni en el repo). Compila primero."
     exit 1
 fi
-cp "$SELF_PATH" "$EBOOT_PATH"
-echo "[makefast] Copiado $SELF_PATH a $EBOOT_PATH"
+
+# Si el archivo seleccionado no está dentro del BUILD_DIR, lo copiaremos dentro para upload
+if [ "$SELECTED_EBOOT" = "$EBOOT_PATH" ]; then
+    echo "[makefast] EBOOT seleccionado: $SELECTED_EBOOT (ya en $EBOOT_PATH). No se copia."
+else
+    echo "[makefast] Copiando $SELECTED_EBOOT -> $EBOOT_PATH"
+    mkdir -p "$(dirname "$EBOOT_PATH")"
+    cp "$SELECTED_EBOOT" "$EBOOT_PATH"
+    echo "[makefast] Copiado $SELECTED_EBOOT a $EBOOT_PATH"
+fi
 
 # 1. Detener la app si está corriendo
 echo "[makefast] Enviando destroy..."

--- a/src/config.c
+++ b/src/config.c
@@ -132,6 +132,10 @@ static int ini_handle(void *out, const char *section, const char *name,
       config->enable_vita_vblank_wait = BOOL(value);
     } else if (strcmp(name, "enable_motion_controls") == 0) {
       config->enable_motion_controls = BOOL(value);
+    } else if (strcmp(name, "enable_front_touchzones") == 0) {
+      config->enable_front_touchzones = BOOL(value);
+    } else if(strcmp(name, "enable_psbutton_capture") == 0) {
+      config->enable_psbutton_capture = BOOL(value);
     } else if (strcmp(name, "enable_double_tap_sprint") == 0) {
       config->enable_double_tap_sprint = BOOL(value);
     } else if (strcmp(name, "double_tap_sprint_step_time") == 0) {
@@ -196,12 +200,14 @@ void config_save(const char* filename, PCONFIGURATION config) {
   write_config_bool(fd, "jp_layout", config->jp_layout);
   write_config_bool(fd, "show_fps", config->show_fps);
   write_config_bool(fd, "save_debug_log", config->save_debug_log);
+  write_config_bool(fd, "enable_front_touchzones", config->enable_front_touchzones);
 
   write_config_int(fd, "mouse_acceleration", config->mouse_acceleration);
   write_config_bool(fd, "enable_ref_frame_invalidation", config->enable_ref_frame_invalidation);
   write_config_int(fd, "enable_remote_stream_optimization", config->stream.streamingRemotely);
   write_config_bool(fd, "enable_vita_vblank_wait", config->enable_vita_vblank_wait);
   write_config_bool(fd, "enable_motion_controls", config->enable_motion_controls);
+  write_config_bool(fd, "enable_psbutton_capture", config->enable_psbutton_capture);
   write_config_bool(fd, "enable_double_tap_sprint", config->enable_double_tap_sprint);
   write_config_int(fd, "double_tap_sprint_step_time", config->double_tap_sprint_step_time);
   write_config_float(fd, "motion_controls_scalar_x", config->motion_controls_scalar_x);
@@ -269,6 +275,7 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   config->enable_frame_pacer = true;
   config->center_region_only = false;
 
+  config->enable_front_touchzones = false;
   config->special_keys.nw = INPUT_SPECIAL_KEY_PAUSE | INPUT_TYPE_SPECIAL;
   config->special_keys.sw = SPECIAL_FLAG | INPUT_TYPE_GAMEPAD;
   config->special_keys.offset = 0;
@@ -277,6 +284,7 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   config->mouse_acceleration = 150;
   config->enable_ref_frame_invalidation = false;
   config->enable_vita_vblank_wait = false;
+  config->enable_psbutton_capture = true;
   config->enable_double_tap_sprint = false;
 
   config->double_tap_sprint_step_time = 200;

--- a/src/config.h
+++ b/src/config.h
@@ -57,6 +57,7 @@ typedef struct _CONFIGURATION {
   bool forcehw;
   bool unsupported_version;
   struct touchscreen_deadzone back_deadzone;
+  bool enable_front_touchzones;
   struct special_keys special_keys;
   bool disable_powersave;
   bool jp_layout;
@@ -70,6 +71,7 @@ typedef struct _CONFIGURATION {
   bool enable_ref_frame_invalidation;
   bool enable_vita_vblank_wait;
   bool enable_motion_controls; //Metalface
+  bool enable_psbutton_capture;
   bool enable_double_tap_sprint; //**
   uint32_t double_tap_sprint_step_time; //** -IN MILLISECONDS
   float motion_controls_scalar_x;//**

--- a/src/gui/ui_settings.c
+++ b/src/gui/ui_settings.c
@@ -440,6 +440,8 @@ enum {
   SETTINGS_ENABLE_MAPPING,
   SETTINGS_BACK_DEADZONE,
   SETTINGS_SPECIAL_KEYS,
+  SETTINGS_ENABLE_SPECIAL_KEYS,
+  SETTINGS_ENABLE_PSBUTTON_CAPTURE,
   // SETTINGS_HOTKEYS, // Eliminado: hotkeys fijos
   SETTINGS_CONTROLLER_TYPE,
   SETTINGS_SWAP_SHOULDER_BUTTONS, // NUEVO: Swap R1/L1 <-> R2/L2
@@ -471,6 +473,8 @@ enum {
   SETTINGS_VIEW_ENABLE_MAPPING,
   SETTINGS_VIEW_BACK_DEADZONE,
   SETTINGS_VIEW_SPECIAL_KEYS,
+  SETTINGS_VIEW_ENABLE_SPECIAL_KEYS,
+  SETTINGS_VIEW_ENABLE_PSBUTTON_CAPTURE,
   // SETTINGS_VIEW_HOTKEYS, // Eliminado: hotkeys fijos
   SETTINGS_VIEW_CONTROLLER_TYPE,
   SETTINGS_VIEW_SWAP_SHOULDER_BUTTONS, // NUEVO: Swap R1/L1 <-> R2/L2
@@ -838,6 +842,22 @@ static int settings_loop(int id, void *context, const input_data *input) {
       }
       special_keys_menu();
       break;
+    case SETTINGS_ENABLE_SPECIAL_KEYS:
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
+        break;
+      }
+
+      config.enable_front_touchzones = !config.enable_front_touchzones;
+      did_change = 1;
+      break;
+    case SETTINGS_ENABLE_PSBUTTON_CAPTURE:
+      if ((input->buttons & config.btn_confirm) == 0 || input->buttons & SCE_CTRL_HOLD) {
+        break;
+      }
+
+      config.enable_psbutton_capture = !config.enable_psbutton_capture;
+      did_change = 1;
+      break;
     case SETTINGS_MOUSE_ACCEL:
       left = input->buttons & SCE_CTRL_LEFT;
       right = input->buttons & SCE_CTRL_RIGHT;
@@ -936,6 +956,12 @@ static int settings_loop(int id, void *context, const input_data *input) {
   sprintf(current, "%s", config.save_debug_log ? "yes" : "no");
   MENU_REPLACE(SETTINGS_VIEW_SAVE_DEBUG_LOG, current);
 
+  sprintf(current, "%s", config.enable_psbutton_capture ? "yes" : "no");
+  MENU_REPLACE(SETTINGS_VIEW_ENABLE_PSBUTTON_CAPTURE, current);
+
+  sprintf(current, "%s", config.enable_front_touchzones ? "yes" : "no");
+  MENU_REPLACE(SETTINGS_VIEW_ENABLE_SPECIAL_KEYS, current);
+
   sprintf(current, "%s", config.mapping != 0 ? "yes" : "no");
   MENU_REPLACE(SETTINGS_VIEW_ENABLE_MAPPING, current);
 
@@ -1025,7 +1051,9 @@ int ui_settings_menu() {
   menu[idx].subname[sizeof(menu[idx].subname) - 1] = '\0';
   idx++;
   MENU_MESSAGE("Example in github repo.");
+  MENU_ENTRY(SETTINGS_ENABLE_PSBUTTON_CAPTURE, SETTINGS_VIEW_ENABLE_PSBUTTON_CAPTURE, "Enable PS button capture", "");
   MENU_ENTRY(SETTINGS_BACK_DEADZONE, SETTINGS_VIEW_BACK_DEADZONE, "Back touchscreen deadzone", "");
+  MENU_ENTRY(SETTINGS_ENABLE_SPECIAL_KEYS, SETTINGS_VIEW_ENABLE_SPECIAL_KEYS, "Enable touchscreen special keys", "");
   MENU_ENTRY(SETTINGS_SPECIAL_KEYS, SETTINGS_VIEW_SPECIAL_KEYS, "Touchscreen special keys", "");
   // MENU_ENTRY(SETTINGS_HOTKEYS, SETTINGS_VIEW_HOTKEYS, "Configure hotkeys", ""); // Eliminado: hotkeys fijos
   // NUEVO: Opción para usar la pantalla táctil como touchpad DS4

--- a/src/input/vita.c
+++ b/src/input/vita.c
@@ -17,6 +17,8 @@
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <psp2common/ctrl.h>
+#include <psp2/shellutil.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -81,6 +83,8 @@ static inline void update_touch_points();
 #define lerp(value, from_max, to_max) ((((value*10) * (to_max*10))/(from_max*10))/10)
 
 double mouse_multiplier;
+
+#define PSBTN_DOUBLETAP_DELAY 250000 // 100ms
 
 #define MOUSE_ACTION_DELAY 100000 // 100ms
 #define MOTION_ACTION_DELAY 200000 // 200ms
@@ -331,7 +335,7 @@ inline void special(uint32_t defined, uint32_t pressed, uint32_t old_pressed) {
   uint32_t dev_val  = defined & INPUT_VALUE_MASK;
 
   if (pressed) {
-    if( dev_val == LEFT_TRIGGER || dev_val == RIGHT_TRIGGER ) {
+    if(dev_val == LEFT_TRIGGER || dev_val == RIGHT_TRIGGER) {
         switch(dev_val) {
           case LEFT_TRIGGER:
             curr.lt = 0xff;
@@ -511,15 +515,18 @@ inline void check_for_double_click(input_data *curr) {
 }
 
 
-static bool has_specialkey( int key ) {
-  if( key == 0 )
-    return !!config.special_keys.nw;
-  if( key == 1 )
-    return !!config.special_keys.ne;
-  if( key == 2 )
-    return !!config.special_keys.sw;
-  if( key == 3 )
-    return !!config.special_keys.se;
+static bool has_specialkey(int key) {
+  if(!config.enable_front_touchzones)
+    return 0;
+
+  switch(key) {
+    case 0: return !!config.special_keys.nw;
+    case 1: return !!config.special_keys.ne;
+    case 2: return !!config.special_keys.sw;
+    case 3: return !!config.special_keys.se;
+  }
+
+  return 0;
 }
 
 // Callback para enviar eventos de mouse absoluto
@@ -533,46 +540,88 @@ static bool has_specialkey( int key ) {
 //     }
 // }
 
-inline void vitainput_process(void) {
-  memset(&pad, 0, sizeof(pad));
-  memset(&touch, 0, sizeof(TouchData));
-  memset(&curr, 0, sizeof(input_data));
-  sceCtrlSetSamplingModeExt(SCE_CTRL_MODE_ANALOG_WIDE);
-  sceCtrlPeekBufferPositiveExt2(controller_port, &pad, 1);
-  sceTouchPeek(SCE_TOUCH_PORT_FRONT, &front, 1);
-  sceTouchPeek(SCE_TOUCH_PORT_BACK, &back, 1);
-  // Siempre actualizar los puntos táctiles del frente
-  update_touch_points();
-  // Siempre procesar las esquinas del back (para compatibilidad o futuros usos)
-  read_backscreen();
-  // --- SOLO PROCESAR SPECIAL KEYS Y ESQUINAS DEL FRENTE SI NO HAY MODO TÁCTIL EXCLUSIVO ACTIVO ---
-
-  // analogs: solo asignar si no están activos por rear touch
-  if (!swap_shoulder_buttons && !is_pressed(map.btn_tl2))
-    curr.lt = read_analog(map.btn_tl); // l2
-  if (!swap_shoulder_buttons && !is_pressed(map.btn_tr2))
-    curr.rt = read_analog(map.btn_tr); // r2
-  if (config.touchscreen_mode <= 1) {
-    read_frontscreen();
-    special(config.special_keys.nw,
-            is_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_NW),
-            is_old_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_NW));
-    special(config.special_keys.ne,
-            is_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_NE),
-            is_old_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_NE));
-    special(config.special_keys.sw,
-            is_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_SW),
-            is_old_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_SW));
-    special(config.special_keys.se,
-            is_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_SE),
-            is_old_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_SE));
-    // Si en el futuro se añade lógica de esquinas/special keys del frente, debe ir aquí dentro
+bool psbutton_locked = 0;
+void lock_psbutton() {
+  if(!psbutton_locked) {
+    sceShellUtilLock((SceShellUtilLockType)SCE_SHELL_UTIL_LOCK_TYPE_PS_BTN | SCE_SHELL_UTIL_LOCK_TYPE_PS_BTN_2);
+    psbutton_locked = 1;
   }
-  // --- FIN BLOQUE SPECIAL KEYS/ESQUINAS DEL FRENTE ---
+}
 
-  sceRtcGetCurrentTick(&current);
+void unlock_psbutton() {
+  if(psbutton_locked) {
+    sceShellUtilUnlock((SceShellUtilLockType)SCE_SHELL_UTIL_LOCK_TYPE_PS_BTN | SCE_SHELL_UTIL_LOCK_TYPE_PS_BTN_2);
+    psbutton_locked = 0;
+  }
+}
 
-  // --- LECTURA DE BOTONES Y STICKS SIEMPRE (antes de los modos táctiles) ---
+SceUInt64 psbutton_pressed_time = 0;
+void handle_psbutton() {
+  SceUInt64 time = sceKernelGetSystemTimeWide();
+
+  if(!config.enable_psbutton_capture) {
+    if(psbutton_locked)
+      unlock_psbutton();
+    return;
+  }
+
+  if(is_pressed(SCE_CTRL_PSBUTTON | INPUT_TYPE_GAMEPAD)) {
+    if(!is_old_pressed(SCE_CTRL_PSBUTTON | INPUT_TYPE_GAMEPAD)) {
+      if(time - psbutton_pressed_time < PSBTN_DOUBLETAP_DELAY)
+        unlock_psbutton();
+      else
+        special(SPECIAL_FLAG | INPUT_TYPE_GAMEPAD, 1, 0);
+    }
+    else {
+      if(psbutton_locked)
+        special(SPECIAL_FLAG | INPUT_TYPE_GAMEPAD, 1, 1);
+      else
+        special(SPECIAL_FLAG | INPUT_TYPE_GAMEPAD, 0, 1);
+    }
+
+    psbutton_pressed_time = time;
+  } else {
+    if(is_old_pressed(SCE_CTRL_PSBUTTON | INPUT_TYPE_GAMEPAD))
+      special(SPECIAL_FLAG | INPUT_TYPE_GAMEPAD, 0, 1);
+
+    if(!psbutton_locked && time - psbutton_pressed_time > PSBTN_DOUBLETAP_DELAY)
+      lock_psbutton();
+  }
+}
+
+bool in_front_touchzone() {
+  for (int i = 0; i < touch.finger; i++) {
+    int x = touch.points[i].x;
+    int y = touch.points[i].y;
+    for (int s = 0; s < 4; s++) {
+      if (has_specialkey(s) && IN_SECTION(FRONT_SECTIONS[s], x, y)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+
+void process_touchzones() {
+  read_frontscreen();
+  special(config.special_keys.nw,
+          is_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_NW),
+          is_old_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_NW));
+  special(config.special_keys.ne,
+          is_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_NE),
+          is_old_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_NE));
+  special(config.special_keys.sw,
+          is_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_SW),
+          is_old_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_SW));
+  special(config.special_keys.se,
+          is_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_SE),
+          is_old_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_SE));
+}
+
+void process_buttons() {
+    // --- LECTURA DE BOTONES Y STICKS SIEMPRE (antes de los modos táctiles) ---
   curr.button |= is_pressed(map.btn_dpad_up)    ? UP_FLAG     : 0;
   curr.button |= is_pressed(map.btn_dpad_left)  ? LEFT_FLAG   : 0;
   curr.button |= is_pressed(map.btn_dpad_down)  ? DOWN_FLAG   : 0;
@@ -583,7 +632,16 @@ inline void vitainput_process(void) {
   curr.button |= is_pressed(map.btn_east)       ? B_FLAG      : 0;
   curr.button |= is_pressed(map.btn_south)      ? A_FLAG      : 0;
   curr.button |= is_pressed(map.btn_west)       ? X_FLAG      : 0;
+  // Zonas inferiores: L3/R3 (nunca swap)
+  if (is_pressed(map.btn_tl2)) {
+    curr.button |= LS_CLK_FLAG; // L3
+  }
+  if (is_pressed(map.btn_tr2)) {
+    curr.button |= RS_CLK_FLAG; // R3
+  }
+}
 
+void process_triggers() {
   // Swap L1<=>L2 y R1<=>R2 correctamente
   if (swap_shoulder_buttons) {
     // Físicos: L1 manda L2 (analógico), rear touch L2 manda L1 (digital)
@@ -630,22 +688,122 @@ inline void vitainput_process(void) {
       // No modificar curr.button aquí
     }
   }
-  // Zonas inferiores: L3/R3 (nunca swap)
-  if (is_pressed(map.btn_tl2)) {
-    curr.button |= LS_CLK_FLAG; // L3
-  }
-  if (is_pressed(map.btn_tr2)) {
-    curr.button |= RS_CLK_FLAG; // R3
-  }
+}
 
-// --- GESTIÓN DE LIMPIEZA DE INPUT AL ABRIR/CERRAR TECLADO VIRTUAL Y PAUSA ---
-static bool keyboard_overlay_active = false;
-static bool pause_overlay_active = false;
-static SceCtrlData pad_snapshot = {0};
-static input_data curr_snapshot = {0};
-
-// Hook para saber si el teclado virtual está abierto
 extern bool keyboardsystem_is_open(void);
+
+void process_touch() {
+  if (config.enable_double_tap_sprint) {
+    check_for_double_click(&curr);
+  }
+
+  if(in_front_touchzone())
+    return;
+
+  // --- PROCESAMIENTO DE MODOS TÁCTILES EXCLUSIVOS ---
+
+  if (config.touchscreen_mode == 1) {
+    touchabsolute_handle_ds4(&touch, &current);
+  } else if (config.touchscreen_mode == 2) {
+    touchabsolute_handle_absolute(&touch, &current, &front_state, &finger_count, &swipe, &touch_old);
+  } else if (config.touchscreen_mode == 3) {
+    touchabsolute_handle_tablet(&touch);
+  } else {
+    static bool mouse_released __attribute__((unused)) = false;
+    mouse_released = false;
+  // mouse y gestos solo si no está en modo touchscreen
+  // Si el toque está en una sección de special key, NO procesar como ratón
+
+    switch (front_state) {
+      case NO_TOUCH_ACTION:
+        if (touch.finger > 0) {
+          front_state = ON_SCREEN_TOUCH;
+          finger_count = touch.finger;
+          sceRtcTickAddMicroseconds(&until, &current, MOUSE_ACTION_DELAY);
+        }
+        break;
+      case ON_SCREEN_TOUCH:
+        if (sceRtcCompareTick(&current, &until) < 0) {
+          if (touch.finger < finger_count) {
+            // TAP
+            if (mouse_click(finger_count, true)) {
+              front_state = SCREEN_TAP;
+              sceRtcTickAddMicroseconds(&until, &current, MOUSE_ACTION_DELAY);
+            } else {
+              front_state = NO_TOUCH_ACTION;
+            }
+          } else if (touch.finger > finger_count) {
+            // finger count changed
+            finger_count = touch.finger;
+          }
+        } else {
+          front_state = SWIPE_START;
+        }
+        break;
+      case SCREEN_TAP:
+        if (sceRtcCompareTick(&current, &until) >= 0) {
+          mouse_click(finger_count, false);
+          front_state = NO_TOUCH_ACTION;
+        }
+        break;
+      case SWIPE_START:
+        memcpy(&swipe, &touch, sizeof(swipe));
+        front_state = ON_SCREEN_SWIPE;
+        break;
+      case ON_SCREEN_SWIPE:
+        if (touch.finger > 0) {
+          switch (touch.finger) {
+            case 1:
+              move_mouse(swipe, touch);
+              break;
+            case 2:
+              move_wheel(swipe, touch);
+              break;
+          }
+          memcpy(&swipe, &touch, sizeof(swipe));
+        } else {
+          front_state = NO_TOUCH_ACTION;
+        }
+        break;
+    }
+  }
+}
+
+inline void vitainput_process(void) {
+  memset(&pad, 0, sizeof(pad));
+  memset(&touch, 0, sizeof(TouchData));
+  memset(&curr, 0, sizeof(input_data));
+  sceCtrlSetSamplingModeExt(SCE_CTRL_MODE_ANALOG_WIDE);
+  sceCtrlPeekBufferPositiveExt2(controller_port, &pad, 1);
+  sceTouchPeek(SCE_TOUCH_PORT_FRONT, &front, 1);
+  sceTouchPeek(SCE_TOUCH_PORT_BACK, &back, 1);
+  // Siempre actualizar los puntos táctiles del frente
+  update_touch_points();
+  // Siempre procesar las esquinas del back (para compatibilidad o futuros usos)
+  read_backscreen();
+
+  sceRtcGetCurrentTick(&current);
+  // analogs: solo asignar si no están activos por rear touch
+  if (!swap_shoulder_buttons && !is_pressed(map.btn_tl2))
+    curr.lt = read_analog(map.btn_tl); // l2
+  if (!swap_shoulder_buttons && !is_pressed(map.btn_tr2))
+    curr.rt = read_analog(map.btn_tr); // r2
+  if (config.enable_front_touchzones) {
+    process_touchzones();
+  }
+  // --- FIN BLOQUE SPECIAL KEYS/ESQUINAS DEL FRENTE ---
+
+  process_buttons();
+  handle_psbutton();
+  process_triggers();
+
+  // --- GESTIÓN DE LIMPIEZA DE INPUT AL ABRIR/CERRAR TECLADO VIRTUAL Y PAUSA ---
+  static bool keyboard_overlay_active = false;
+  static bool pause_overlay_active = false;
+  static SceCtrlData pad_snapshot = {0};
+  static input_data curr_snapshot = {0};
+
+  // Hook para saber si el teclado virtual está abierto
 
   bool shortcut_triggered = process_physical_shortcuts(&pad, &pad_old);
   bool keyboard_now = keyboardsystem_is_open();
@@ -709,90 +867,7 @@ extern bool keyboardsystem_is_open(void);
   curr.rx = read_analog(map.abs_rx);
   curr.ry = read_analog(map.abs_ry);
 
-  if (config.enable_double_tap_sprint) {
-    check_for_double_click(&curr);
-  }
-  bool in_special_key = false;
-  for (int i = 0; i < touch.finger; i++) {
-    int x = touch.points[i].x;
-    int y = touch.points[i].y;
-    for (int s = 0; s < 4; s++) {
-      if (has_specialkey(s) && IN_SECTION(FRONT_SECTIONS[s], x, y)) {
-        in_special_key = true;
-        break;
-      }
-    }
-    if (in_special_key) break;
-  }
-  // --- PROCESAMIENTO DE MODOS TÁCTILES EXCLUSIVOS ---
-  if (config.touchscreen_mode == 1) {
-    if( !in_special_key )
-      touchabsolute_handle_ds4(&touch, &current);
-  } else if (config.touchscreen_mode == 2) {
-    touchabsolute_handle_absolute(&touch, &current, &front_state, &finger_count, &swipe, &touch_old);
-  } else if (config.touchscreen_mode == 3) {
-    touchabsolute_handle_tablet(&touch);
-  } else {
-    static bool mouse_released __attribute__((unused)) = false;
-    mouse_released = false;
-  // mouse y gestos solo si no está en modo touchscreen
-  // Si el toque está en una sección de special key, NO procesar como ratón
-
-  if (!in_special_key) {
-    switch (front_state) {
-      case NO_TOUCH_ACTION:
-        if (touch.finger > 0) {
-          front_state = ON_SCREEN_TOUCH;
-          finger_count = touch.finger;
-          sceRtcTickAddMicroseconds(&until, &current, MOUSE_ACTION_DELAY);
-        }
-        break;
-      case ON_SCREEN_TOUCH:
-        if (sceRtcCompareTick(&current, &until) < 0) {
-          if (touch.finger < finger_count) {
-            // TAP
-            if (mouse_click(finger_count, true)) {
-              front_state = SCREEN_TAP;
-              sceRtcTickAddMicroseconds(&until, &current, MOUSE_ACTION_DELAY);
-            } else {
-              front_state = NO_TOUCH_ACTION;
-            }
-          } else if (touch.finger > finger_count) {
-            // finger count changed
-            finger_count = touch.finger;
-          }
-        } else {
-          front_state = SWIPE_START;
-        }
-        break;
-      case SCREEN_TAP:
-        if (sceRtcCompareTick(&current, &until) >= 0) {
-          mouse_click(finger_count, false);
-          front_state = NO_TOUCH_ACTION;
-        }
-        break;
-      case SWIPE_START:
-        memcpy(&swipe, &touch, sizeof(swipe));
-        front_state = ON_SCREEN_SWIPE;
-        break;
-      case ON_SCREEN_SWIPE:
-        if (touch.finger > 0) {
-          switch (touch.finger) {
-            case 1:
-              move_mouse(swipe, touch);
-              break;
-            case 2:
-              move_wheel(swipe, touch);
-              break;
-          }
-          memcpy(&swipe, &touch, sizeof(swipe));
-        } else {
-          front_state = NO_TOUCH_ACTION;
-        }
-        break;
-    }
-  }
-  }
+  process_touch();
 
   // --- ENVÍO DE EVENTOS DE GAMEPAD SOLO SI NO hay overlay de teclado activo ---
   // O si el overlay está activo pero NO están ambos botones del shortcut presionados
@@ -952,11 +1027,15 @@ void vitainput_start(void) {
 
   LiSendControllerBatteryEvent(0, LI_BATTERY_STATE_FULL, 100);
 
+  if(config.enable_psbutton_capture)
+    lock_psbutton();
+
   active_input_thread = true;
   active_motion_threads = true;
 }
 
 void vitainput_stop(void) {
+  unlock_psbutton();
   active_input_thread = false;
   active_motion_threads = false;
 }

--- a/src/input/vita.c
+++ b/src/input/vita.c
@@ -331,6 +331,17 @@ inline void special(uint32_t defined, uint32_t pressed, uint32_t old_pressed) {
   uint32_t dev_val  = defined & INPUT_VALUE_MASK;
 
   if (pressed) {
+    if( dev_val == LEFT_TRIGGER || dev_val == RIGHT_TRIGGER ) {
+        switch(dev_val) {
+          case LEFT_TRIGGER:
+            curr.lt = 0xff;
+            return;
+          case RIGHT_TRIGGER:
+            curr.rt = 0xff;
+            return;
+        }
+    }
+
     switch(dev_type) {
       case INPUT_TYPE_SPECIAL:
         // Limpiar input físico ANTES de overlays/eventos modales
@@ -372,16 +383,6 @@ inline void special(uint32_t defined, uint32_t pressed, uint32_t old_pressed) {
         return;
       case INPUT_TYPE_GAMEPAD:
         curr.button |= dev_val;
-        return;
-      case INPUT_TYPE_ANALOG:
-        switch(dev_val) {
-          case LEFT_TRIGGER:
-            curr.lt = 0xff;
-            return;
-          case RIGHT_TRIGGER:
-            curr.rt = 0xff;
-            return;
-        }
         return;
       case INPUT_TYPE_MOUSE:
         if (!old_pressed) {
@@ -510,6 +511,17 @@ inline void check_for_double_click(input_data *curr) {
 }
 
 
+static bool has_specialkey( int key ) {
+  if( key == 0 )
+    return !!config.special_keys.nw;
+  if( key == 1 )
+    return !!config.special_keys.ne;
+  if( key == 2 )
+    return !!config.special_keys.sw;
+  if( key == 3 )
+    return !!config.special_keys.se;
+}
+
 // Callback para enviar eventos de mouse absoluto
 // static void send_absolute_mouse_event(int x, int y, bool down) {
 //     if (down) {
@@ -534,7 +546,13 @@ inline void vitainput_process(void) {
   // Siempre procesar las esquinas del back (para compatibilidad o futuros usos)
   read_backscreen();
   // --- SOLO PROCESAR SPECIAL KEYS Y ESQUINAS DEL FRENTE SI NO HAY MODO TÁCTIL EXCLUSIVO ACTIVO ---
-  if (config.touchscreen_mode == 0) {
+
+  // analogs: solo asignar si no están activos por rear touch
+  if (!swap_shoulder_buttons && !is_pressed(map.btn_tl2))
+    curr.lt = read_analog(map.btn_tl); // l2
+  if (!swap_shoulder_buttons && !is_pressed(map.btn_tr2))
+    curr.rt = read_analog(map.btn_tr); // r2
+  if (config.touchscreen_mode <= 1) {
     read_frontscreen();
     special(config.special_keys.nw,
             is_pressed(INPUT_TYPE_TOUCHSCREEN | TOUCHSEC_SPECIAL_NW),
@@ -686,11 +704,6 @@ extern bool keyboardsystem_is_open(void);
     curr.rt = 0;
   }
 
-  // analogs: solo asignar si no están activos por rear touch
-  if (!swap_shoulder_buttons && !is_pressed(map.btn_tl2))
-    curr.lt = read_analog(map.btn_tl); // l2
-  if (!swap_shoulder_buttons && !is_pressed(map.btn_tr2))
-    curr.rt = read_analog(map.btn_tr); // r2
   curr.lx = read_analog(map.abs_x);
   curr.ly = read_analog(map.abs_y);
   curr.rx = read_analog(map.abs_rx);
@@ -699,10 +712,22 @@ extern bool keyboardsystem_is_open(void);
   if (config.enable_double_tap_sprint) {
     check_for_double_click(&curr);
   }
-
+  bool in_special_key = false;
+  for (int i = 0; i < touch.finger; i++) {
+    int x = touch.points[i].x;
+    int y = touch.points[i].y;
+    for (int s = 0; s < 4; s++) {
+      if (has_specialkey(s) && IN_SECTION(FRONT_SECTIONS[s], x, y)) {
+        in_special_key = true;
+        break;
+      }
+    }
+    if (in_special_key) break;
+  }
   // --- PROCESAMIENTO DE MODOS TÁCTILES EXCLUSIVOS ---
   if (config.touchscreen_mode == 1) {
-    touchabsolute_handle_ds4(&touch, &current);
+    if( !in_special_key )
+      touchabsolute_handle_ds4(&touch, &current);
   } else if (config.touchscreen_mode == 2) {
     touchabsolute_handle_absolute(&touch, &current, &front_state, &finger_count, &swipe, &touch_old);
   } else if (config.touchscreen_mode == 3) {
@@ -712,18 +737,7 @@ extern bool keyboardsystem_is_open(void);
     mouse_released = false;
   // mouse y gestos solo si no está en modo touchscreen
   // Si el toque está en una sección de special key, NO procesar como ratón
-  bool in_special_key = false;
-  for (int i = 0; i < touch.finger; i++) {
-    int x = touch.points[i].x;
-    int y = touch.points[i].y;
-    for (int s = 0; s < 4; s++) {
-      if (IN_SECTION(FRONT_SECTIONS[s], x, y)) {
-        in_special_key = true;
-        break;
-      }
-    }
-    if (in_special_key) break;
-  }
+
   if (!in_special_key) {
     switch (front_state) {
       case NO_TOUCH_ACTION:

--- a/src/main.c
+++ b/src/main.c
@@ -50,6 +50,7 @@
 
 #include <psp2/io/stat.h>
 
+#include <psp2/shellutil.h>
 #include <psp2/sysmodule.h>
 #include <psp2/ctrl.h>
 #include <psp2/touch.h>
@@ -80,6 +81,8 @@ void loop_forever(void) {
 }
 
 static void vita_init() {
+  sceShellUtilInitEvents(0);
+
   // Seed OpenSSL with Sony-grade random number generator
   char random_seed[0x40] = {0};
   sceKernelGetRandomNumber(random_seed, sizeof(random_seed));


### PR DESCRIPTION
i decided to clean my personal fork up and create a pull request since some of it might be useful.

changes:

- added PS button capture
  - when enabled, double-pressing the PS button will go to menu, single press is passed as PS/Xbox button to sunshine
  - this required disabling the safe (-s) flag in vita-make-fself and adding the SceShell permission (0x2800000000000001)
- allow enabling/disabling touch zones independent of touch mode (separate setting)
  - allows using front screen touch zones regardless of touch input mode. when a touch zone is pressed, the touch input is ignored. unused touch zones are ignored and function as normal touch area.

bug fixes:
- fixed front touch zone L2/R2 special keys not working

refactor:
- split vitainput_process into multiple smaller functions for better code readability